### PR TITLE
Fix and harden the NixOS module and package derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         in
         python.pkgs.buildPythonApplication {
           pname = "feedecho";
-          version = "1.5.0";
+          version = "1.9.0";
           src = ./.;
           format = "pyproject";
 
@@ -46,8 +46,20 @@
           doCheck = false;
 
           # Expose the Python interpreter so the NixOS module can derive
-          # the correct site-packages path.
-          passthru.python = python;
+          # the correct site-packages path, plus a consolidated runtime
+          # env (uvicorn + all deps) so the module can exec uvicorn.
+          passthru = {
+            inherit python;
+            env = python.withPackages (ps: with ps; [
+              fastapi
+              uvicorn
+              jinja2
+              python-multipart
+              feedparser
+              httpx
+              apscheduler
+            ]);
+          };
 
           meta = with pkgs.lib; {
             description = "Self-hosted RSS feed cross-poster — route feed items to Mastodon";
@@ -64,7 +76,7 @@
         { config, lib, pkgs', ... }:
         import ./nix/module.nix {
           inherit config lib;
-          pkgs = pkgs // { feedecho-pkg = mkPackage pkgs; };
+          pkgs = pkgs // { feedecho-flake-pkg = mkPackage pkgs; };
         };
     in
     {

--- a/nix/README.md
+++ b/nix/README.md
@@ -56,9 +56,9 @@ let
     type = "github";
     owner = "jcrabapple";
     repo = "feedecho";
-    rev = "v1.5.0";
+    rev = "v1.9.0";
   };
-  feedechoPkg = pkgs.callPackage (feedechoSrc + "/nix/package.nix") { };
+  feedechoPkg = pkgs.callPackage (feedechoSrc + "/nix/package.nix") { src = feedechoSrc; };
 in {
   # Import the module and pass the package
   imports = [ (feedechoSrc + "/nix/module.nix") ];
@@ -74,11 +74,13 @@ in {
 }
 ```
 
-**Note:** The `fetchTree` hash in `nix/package.nix` is `lib.fakeHash` by default.
-Replace it with the real hash after the first build:
+**Note:** Passing `src = feedechoSrc` builds from your fetched checkout, so no
+dependency hash is needed. If you omit `src`, `nix/package.nix` falls back to
+fetching from GitHub and needs its `fetchFromGitHub` hash set — it is
+`lib.fakeHash` by default. Replace it after the first build:
 
 ```bash
-nix-prefetch-url --unpack https://github.com/jcrabapple/feedecho/archive/refs/tags/v1.5.0.tar.gz
+nix-prefetch-url --unpack https://github.com/jcrabapple/feedecho/archive/refs/tags/v1.9.0.tar.gz
 ```
 
 ## Auth token

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -27,6 +27,16 @@ let
       "${cfg.package}/lib/${cfg.package.python.libPrefix}/site-packages"
     else
       "${cfg.package}/lib/python3.12/site-packages";
+
+  # The wheel does not ship a console script, so exec uvicorn from the
+  # package's consolidated runtime env (uvicorn + all deps).
+  uvicornBin =
+    if cfg.package ? env then
+      "${cfg.package.env}/bin/uvicorn"
+    else if cfg.package ? python then
+      "${cfg.package.python.pkgs.uvicorn}/bin/uvicorn"
+    else
+      "${pkgs.python3.pkgs.uvicorn}/bin/uvicorn";
 in {
   options.services.feedecho = {
     enable = lib.mkEnableOption "FeedEcho RSS feed cross-poster";
@@ -147,13 +157,14 @@ in {
       };
 
       # Read the auth token from the credential file and exec uvicorn.
-      # We cd into site-packages so app.py, templates/, and static/ are
-      # all resolvable. The path is derived from the package's Python
-      # interpreter to avoid hardcoding a version.
+      # app.py, templates/, and static/ live in the package's own
+      # site-packages; uvicorn and the app's dependencies live in the
+      # consolidated runtime env. Put both on PYTHONPATH so the "app"
+      # import resolves.
       script = ''
-        cd "${pythonSitePackages}"
         export FEEDCHO_AUTH_TOKEN=$(cat "$CREDENTIALS_DIRECTORY/auth_token")
-        exec ${cfg.package}/bin/uvicorn app:app --host 0.0.0.0 --port ${toString cfg.port}
+        export PYTHONPATH="${pythonSitePackages}:$PYTHONPATH"
+        exec ${uvicornBin} app:app --host 0.0.0.0 --port ${toString cfg.port}
       '';
     };
   };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -103,9 +103,47 @@ in {
 
         # Hardening
         NoNewPrivileges = true;
+
+        # Process isolation
+        PrivateMounts = true;
         PrivateTmp = true;
-        ProtectSystem = "strict";
+        RemoveIPC = true;
+
+        # Filesystem
         ProtectHome = true;
+        ProtectSystem = "strict";
+        UMask = "0077";
+
+        # Kernel
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+
+        # Capabilities
+        AmbientCapabilities = [ ];
+        CapabilityBoundingSet = [ ];
+        RestrictSUIDSGID = true;
+
+        # Memory
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+
+        # Devices
+        PrivateDevices = true;
+
+        # Network
+        # HTTP(S) and Unix sockets for the web UI, outbound feed/API polling,
+        # SMTP, and DNS resolution via the resolver socket.
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" "AF_NETLINK" ];
+
+        # Misc
+        KeyringMode = "private";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
       };
 
       # Read the auth token from the credential file and exec uvicorn.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -11,7 +11,7 @@
 # Then `nixos-rebuild switch`. The app runs on port 8453 by default.
 # Put a reverse proxy (nginx, caddy) in front for TLS.
 
-{ config, lib, pkgs }:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.services.feedecho;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,12 +1,13 @@
 # Standalone package derivation (for non-flake NixOS users)
 # Used by nix/module.nix default when not consuming via flake.nix.
 { lib
-, python ? python3
+, python3
+, pythonPkg ? python3
 , fetchFromGitHub ? null
 , src ? null
 }:
 
-python.pkgs.buildPythonApplication {
+pythonPkg.pkgs.buildPythonApplication {
   pname = "feedecho";
   version = "1.5.0";
 
@@ -19,9 +20,9 @@ python.pkgs.buildPythonApplication {
 
   format = "pyproject";
 
-  nativeBuildInputs = [ python.pkgs.hatchling ];
+  nativeBuildInputs = [ pythonPkg.pkgs.hatchling ];
 
-  propagatedBuildInputs = with python.pkgs; [
+  propagatedBuildInputs = with pythonPkg.pkgs; [
     fastapi
     uvicorn
     jinja2
@@ -31,7 +32,7 @@ python.pkgs.buildPythonApplication {
     apscheduler
   ];
 
-  nativeCheckInputs = with python.pkgs; [ pytest pytest-asyncio ];
+  nativeCheckInputs = with pythonPkg.pkgs; [ pytest pytest-asyncio ];
 
   checkPhase = ''
     runHook preCheck
@@ -43,7 +44,7 @@ python.pkgs.buildPythonApplication {
 
   # Expose the Python interpreter so the module can derive the correct
   # site-packages path without hardcoding "python3.12".
-  passthru.python = python;
+  passthru.python = pythonPkg;
 
   meta = with lib; {
     description = "Self-hosted RSS feed cross-poster";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -9,12 +9,12 @@
 
 pythonPkg.pkgs.buildPythonApplication {
   pname = "feedecho";
-  version = "1.5.0";
+  version = "1.9.0";
 
   src = if src != null then src else fetchFromGitHub {
     owner = "jcrabapple";
     repo = "feedecho";
-    rev = "v1.5.0";
+    rev = "v1.9.0";
     hash = lib.fakeHash; # replace after first build: `nix-prefetch-url --unpack <url>`
   };
 
@@ -43,8 +43,21 @@ pythonPkg.pkgs.buildPythonApplication {
   doCheck = false;
 
   # Expose the Python interpreter so the module can derive the correct
-  # site-packages path without hardcoding "python3.12".
-  passthru.python = pythonPkg;
+  # site-packages path without hardcoding "python3.12". Also expose a
+  # consolidated runtime environment (uvicorn + all deps) so the module
+  # can exec uvicorn from a single path.
+  passthru = {
+    python = pythonPkg;
+    env = pythonPkg.withPackages (ps: with ps; [
+      fastapi
+      uvicorn
+      jinja2
+      python-multipart
+      feedparser
+      httpx
+      apscheduler
+    ]);
+  };
 
   meta = with lib; {
     description = "Self-hosted RSS feed cross-poster";


### PR DESCRIPTION
## Summary

Fixes the NixOS packaging so the module evaluates and the service actually runs, and hardens the systemd unit.

## Changes

- **Fix module signature** — function was missing `...`, so importing it failed with "unexpected arguments".
- **Fix package derivation** — renamed the colliding/out-of-scope `python` default to `pythonPkg`, fixing `callPackage`.
- **Fix service startup** — the wheel ships no console script; derivations now expose `passthru.env` (uvicorn + all runtime deps) and the module execs uvicorn from it, with the package's site-packages on `PYTHONPATH`.
- **Harden systemd service** — process/fs/kernel isolation, capability dropping, `PrivateDevices`, `RestrictAddressFamilies`, `MemoryDenyWriteExecute`, and more.
- **Align version and docs** — bump to `1.9.0` (matches `pyproject.toml`), fix `mkNixosModule` injection key, refresh stale `v1.5.0` references and add `src` to the non-flake example.