### PR TITLE
Design-patterns audit fixes: destination-dispatch Strategy, shared exception hierarchy, auth-mode split

### DIFF
--- a/app.py
+++ b/app.py
@@ -2374,7 +2374,38 @@ async def history_page(request: Request, feed: str = "", account: str = "", item
 # ── Reader keyset pagination & search helpers ──────────────────────────────
 READER_PAGE_SIZE = 50
 _CURSOR_RE = re.compile(r"^[0-9 :.\-]*\|\d+$")
-_saved_search_counts_cache: dict[int, tuple[int, float, dict[int, int]]] = {}
+
+
+class _SavedSearchCountsCache:
+    """Per-user, 60s TTL cache of saved-search unread counts.
+
+    Invalidation is keyed by max_item_id (see .get()) rather than pure
+    time, so a stale entry never outlives the item that would change it by
+    more than the TTL. Every route that mutates saved searches, feeds, or
+    read-state must call .invalidate(uid) — wrapped in a class (instead of
+    the previous bare module-level dict) so every one of those 9 call
+    sites reads as an obvious, greppable method name rather than a
+    dict.pop() that looks like ordinary housekeeping and is easy to miss
+    in a diff. Design-patterns audit finding 2.8.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[int, tuple[int, float, dict[int, int]]] = {}
+
+    def get(self, uid: int, max_item_id: int, now: float, ttl: int = 60) -> dict[int, int] | None:
+        cached = self._store.get(uid)
+        if cached and cached[0] == max_item_id and (now - cached[1]) < ttl:
+            return cached[2]
+        return None
+
+    def set(self, uid: int, max_item_id: int, now: float, counts: dict[int, int]) -> None:
+        self._store[uid] = (max_item_id, now, counts)
+
+    def invalidate(self, uid: int) -> None:
+        self._store.pop(uid, None)
+
+
+_saved_search_counts_cache = _SavedSearchCountsCache()
 
 
 def _reader_keyset(cursor: str | None) -> tuple[str, list]:
@@ -2681,9 +2712,9 @@ async def reader_page(
         saved_search_counts: dict[int, int] = {}
         if saved_searches:
             now_time = time.time()
-            cached = _saved_search_counts_cache.get(uid)
-            if cached and cached[0] == max_item_id and (now_time - cached[1]) < 60:
-                saved_search_counts = cached[2]
+            cached = _saved_search_counts_cache.get(uid, max_item_id, now_time)
+            if cached is not None:
+                saved_search_counts = cached
             else:
                 # Pre-load mute keywords once for all saved-search count queries
                 mutes = db.execute(
@@ -2755,7 +2786,7 @@ async def reader_page(
                         tuple(s_params),
                     ).fetchone()
                     saved_search_counts[s["id"]] = cnt_row["c"] if cnt_row else 0
-                _saved_search_counts_cache[uid] = (max_item_id, now_time, saved_search_counts)
+                _saved_search_counts_cache.set(uid, max_item_id, now_time, saved_search_counts)
 
     # Progressive enhancement: fetch request with X-Requested-With returns the
     # items fragment alone (for infinite scroll / load more).
@@ -3041,7 +3072,7 @@ def _hard_delete_user(db, uid: int) -> None:
     db.execute("DELETE FROM email_tokens WHERE user_id = ?", (uid,))
     db.execute("DELETE FROM users WHERE id = ?", (uid,))
     # Clean up the in-process saved-search count cache for this deleted user
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
 
 
 @app.post("/settings/delete-account")
@@ -4014,7 +4045,7 @@ def create_saved_search(
         ).fetchone()
 
     # Invalidate count cache for this user
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
 
     if request.headers.get("accept", "").startswith("application/json"):
         return {"success": True, "id": row["id"], "name": name, "query": query}
@@ -4049,7 +4080,7 @@ def rename_saved_search(request: Request, search_id: int, name: str = Form(...))
             (name, search_id, uid),
         )
 
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
     if request.headers.get("accept", "").startswith("application/json"):
         return {"success": True, "name": name}
     return RedirectResponse(url=f"/reader?saved={search_id}", status_code=303)
@@ -4072,7 +4103,7 @@ def delete_saved_search(request: Request, search_id: int):
             (search_id, uid),
         )
 
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
     if request.headers.get("accept", "").startswith("application/json"):
         return {"success": True}
     return RedirectResponse(url="/reader", status_code=303)
@@ -4730,7 +4761,7 @@ def reader_toggle_read(request: Request, item_id: int):
         if result.rowcount != 1:
             raise HTTPException(status_code=404, detail="Item not found")
         row = db.execute("SELECT is_read FROM feed_items WHERE id = ?", (item_id,)).fetchone()
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
     return {"success": True, "is_read": bool(row["is_read"])}
 
 
@@ -4747,7 +4778,7 @@ def reader_toggle_star(request: Request, item_id: int):
         if result.rowcount != 1:
             raise HTTPException(status_code=404, detail="Item not found")
         row = db.execute("SELECT starred FROM feed_items WHERE id = ?", (item_id,)).fetchone()
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
     return {"success": True, "starred": bool(row["starred"])}
 
 
@@ -4803,7 +4834,7 @@ def reader_mark_all_read(
                 " (SELECT id FROM feeds WHERE user_id = ? AND deleted_at IS NULL)",
                 (uid,),
             )
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
     ids = [r["id"] for r in rows]
     return {"success": True, "count": len(ids), "ids": ids}
 
@@ -4831,7 +4862,7 @@ def reader_mark_unread(request: Request, ids: str = Form("")):
             " AND feed_id IN (SELECT id FROM feeds WHERE user_id = ? AND deleted_at IS NULL)",
             (*id_list, uid),
         )
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
     return {"success": True, "count": result.rowcount}
 
 
@@ -4859,7 +4890,7 @@ def reader_mark_read(request: Request, ids: str = Form("")):
             " AND feed_id IN (SELECT id FROM feeds WHERE user_id = ? AND deleted_at IS NULL)",
             (*id_list, uid),
         )
-    _saved_search_counts_cache.pop(uid, None)
+    _saved_search_counts_cache.invalidate(uid)
     return {"success": True, "count": result.rowcount}
 
 

--- a/auth.py
+++ b/auth.py
@@ -368,49 +368,46 @@ def login_page(request: Request):
     return _render_auth(request, "login.html", multi=True)
 
 
-def login_submit(
-    request: Request,
-    email: str = Form(""),
-    password: str = Form(""),
-    token: str = Form(""),
-):
-    if not settings.MULTI:
-        # Single mode: shared-secret token (original behavior).
-        import secrets as _secrets
+def _login_single_mode(request: Request, token: str):
+    """Shared-secret token login (original single-tenant behavior)."""
+    import secrets as _secrets
 
-        if not settings.AUTH_TOKEN:
-            return RedirectResponse(url="/", status_code=302)
-        ip = _client_ip(request)
-        # Verify first, throttle second. Gating the comparison on the bucket
-        # would let anyone who can reach /login keep the operator out of their
-        # own instance indefinitely by POSTing wrong tokens: single mode has no
-        # second credential and no account recovery. A correct token always
-        # works and clears the bucket; wrong ones are what get rate limited.
-        #
-        # Compare bytes: compare_digest raises TypeError on non-ASCII str.
-        if token and _secrets.compare_digest(
-            token.encode("utf-8", "surrogatepass"),
-            settings.AUTH_TOKEN.encode("utf-8", "surrogatepass"),
-        ):
-            _clear_failures(ip)
-            response = RedirectResponse(url="/", status_code=302)
-            response.set_cookie(
-                key=AUTH_COOKIE_NAME,
-                value=token,
-                httponly=True,
-                samesite="lax",
-                secure=request.url.scheme == "https" or settings.FORCE_SECURE_COOKIE,
-            )
-            return response
-        _record_failure(ip)
-        if _throttled(ip):
-            return _render_auth(
-                request,
-                "login.html",
-                error="Too many failed attempts. Try again in a few minutes.",
-            )
-        return _render_auth(request, "login.html", error="Invalid token")
+    if not settings.AUTH_TOKEN:
+        return RedirectResponse(url="/", status_code=302)
+    ip = _client_ip(request)
+    # Verify first, throttle second. Gating the comparison on the bucket
+    # would let anyone who can reach /login keep the operator out of their
+    # own instance indefinitely by POSTing wrong tokens: single mode has no
+    # second credential and no account recovery. A correct token always
+    # works and clears the bucket; wrong ones are what get rate limited.
+    #
+    # Compare bytes: compare_digest raises TypeError on non-ASCII str.
+    if token and _secrets.compare_digest(
+        token.encode("utf-8", "surrogatepass"),
+        settings.AUTH_TOKEN.encode("utf-8", "surrogatepass"),
+    ):
+        _clear_failures(ip)
+        response = RedirectResponse(url="/", status_code=302)
+        response.set_cookie(
+            key=AUTH_COOKIE_NAME,
+            value=token,
+            httponly=True,
+            samesite="lax",
+            secure=request.url.scheme == "https" or settings.FORCE_SECURE_COOKIE,
+        )
+        return response
+    _record_failure(ip)
+    if _throttled(ip):
+        return _render_auth(
+            request,
+            "login.html",
+            error="Too many failed attempts. Try again in a few minutes.",
+        )
+    return _render_auth(request, "login.html", error="Invalid token")
 
+
+def _login_multi_mode(request: Request, email: str, password: str):
+    """Email + password + session login (multi-tenant behavior)."""
     ip = _client_ip(request)
     if _throttled(ip):
         return _render_auth(
@@ -449,6 +446,26 @@ def login_submit(
     response = RedirectResponse(url="/", status_code=302)
     _set_session_cookie(response, user["id"], user["email"], request, user["session_epoch"])
     return response
+
+
+def login_submit(
+    request: Request,
+    email: str = Form(""),
+    password: str = Form(""),
+    token: str = Form(""),
+):
+    """Dispatch to the mode-appropriate login strategy.
+
+    Single-tenant and multi-tenant login are different algorithms (a
+    shared-secret token compare vs. an email/password/session lookup)
+    that happened to share one function; split per the design-patterns
+    audit's Strategy-pattern finding 3.2 so each mode reads as its own
+    self-contained flow instead of one function branching for its entire
+    body.
+    """
+    if not settings.MULTI:
+        return _login_single_mode(request, token)
+    return _login_multi_mode(request, email, password)
 
 
 def logout(request: Request):

--- a/bluesky.py
+++ b/bluesky.py
@@ -19,7 +19,7 @@ from urllib.parse import quote
 import httpx
 
 from feed_parser import SSRFError, pinned_request, validate_outbound_url
-from utils import json_error_detail
+from utils import DestinationAuthError, DestinationError, json_error_detail
 
 PUBLIC_API = "https://public.api.bsky.app"
 PLC_DIRECTORY = "https://plc.directory"
@@ -36,11 +36,11 @@ BLUESKY_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 DEFAULT_SESSION_TTL_SECONDS = 2 * 60 * 60
 
 
-class BlueskyError(Exception):
+class BlueskyError(DestinationError):
     """Base error for Bluesky API interactions."""
 
 
-class BlueskyAuthError(BlueskyError):
+class BlueskyAuthError(BlueskyError, DestinationAuthError):
     """Credentials rejected, session expired, or app password revoked."""
 
 

--- a/discord.py
+++ b/discord.py
@@ -40,6 +40,10 @@ import httpx
 from feed_parser import SSRFError, pinned_request
 from utils import (
     DEFAULT_REQUEST_TIMEOUT,
+    DestinationAuthError,
+    DestinationError,
+    DestinationNotFoundError,
+    DestinationRateLimitError,
     json_error_detail,
     parse_retry_after,
     truncate_chars,
@@ -64,11 +68,11 @@ _WEBHOOK_URL_RE = re.compile(
 )
 
 
-class DiscordError(Exception):
+class DiscordError(DestinationError):
     """Base error for Discord webhook API interactions."""
 
 
-class DiscordRateLimitError(DiscordError):
+class DiscordRateLimitError(DiscordError, DestinationRateLimitError):
     """Discord 429 rate limit. Carries Discord's suggested wait in seconds.
 
     Still a transient error (the scheduler's bounded backoff retries it), but
@@ -83,11 +87,11 @@ class DiscordRateLimitError(DiscordError):
         super().__init__(msg)
 
 
-class DiscordAuthError(DiscordError):
+class DiscordAuthError(DiscordError, DestinationAuthError):
     """Webhook URL rejected (invalid token)."""
 
 
-class DiscordNotFoundError(DiscordError):
+class DiscordNotFoundError(DiscordError, DestinationNotFoundError):
     """Webhook no longer exists (deleted from the server)."""
 
 

--- a/docs/reviews/2026-09-08-code-complexity-audit.md
+++ b/docs/reviews/2026-09-08-code-complexity-audit.md
@@ -1,0 +1,510 @@
+# FeedEcho — Code Complexity Audit
+
+**Date:** 2026-09-08
+**Scope:** All Python modules at commit `3dcf392` (v1.49.0), excluding `tests/`.
+**Status:** reference snapshot, not yet actioned. `docs/reviews/2026-09-08-code-duplication-audit.md` (its §7) and `docs/reviews/2026-09-08-design-patterns-audit.md` (its adoption-outcome section) each record what was actually implemented from their own findings; several of those changes (e.g. the destination-dispatch registry, `scheduler.py`'s shared skeleton extraction) also reduce cyclomatic complexity reported here, but this document's line numbers and CC figures were not re-measured after those changes landed.
+**Method:** Objective metrics computed with tooling, not estimated:
+- **Cyclomatic complexity (CC) & Maintainability Index (MI):** [`radon`](https://radon.readthedocs.io/) 6.0.1, run against every file (`radon cc -s -n A -a`, `radon mi -s`).
+- **Function/class line counts:** exact, via Python's `ast` module (`end_lineno - lineno + 1`), not line-diffing between `def`s.
+- **Coupling (Ce/Ca/instability):** exact, via an `ast`-based import graph over all 25 local top-level modules (module names resolved against local filenames only; stdlib/third-party imports excluded).
+- **Cognitive complexity, nesting depth, mixed-abstraction, and refactor snippets:** manual read of every function flagged by the objective metrics above (all line ranges below were read directly, not inferred from the CC number alone).
+
+Companion document: `audits/CODE_DUPLICATION_AUDIT.md` (2026-09-08) — several findings below are the *complexity* side of duplication already documented there; cross-references are marked `[DUP §x.x]`.
+
+**A note on reading CC scores in this report:** cyclomatic complexity counts decision points, and McCabe's original definition counts every `or`, `and`, and ternary in a boolean expression as its own branch. Several functions below have double-digit CC from a flat chain of independent `x or default` fallbacks or early-return guard clauses — genuinely easy to read despite the score. Those are explicitly called out as **"CC overstates difficulty"** so the score isn't applied mechanically. Radon grade bands used throughout: A (1-5), B (6-10), C (11-20), D (21-30), E (31-40), F (41+).
+
+---
+
+## Summary
+
+| # | Finding | Metric | Location | Importance |
+|---|---|---|---|---|
+| 1 | `reader_page` — worst function in the codebase, ~half its CC is a duplicated query-builder | CC 76 (F), 349 lines | `app.py:2467` | **9/10** |
+| 2 | 7 `_send_X` destination dispatchers in `scheduler.py` — deep image-pipeline nesting on the hot posting path | CC 41/33/27/24/18 | `scheduler.py` | **8/10** |
+| 3 | `import_data` — 5 mixed concerns flattened into one function | CC 51 (F), 185 lines | `import_export.py:327` | **7/10** |
+| 4 | `_flush_queue` — 5 mixed concerns + a real duplicated retry-backoff block | CC 33 (E), 243 lines | `scheduler.py:2280` | **7/10** |
+| 5 | `reader_compose` — two full parallel request/response cycles in one function | CC 49 (F), 207 lines | `app.py:5115` | **7/10** |
+| 6 | `add_echo` / `edit_echo` — ~90% duplicate functions, no destination-type registry | CC 29 (D) each | `app.py:5395`, `app.py:5528` | **6/10** |
+| 7 | feed_parser.py image-extraction cluster — dedup fix also fixes a real behavioral divergence | CC 22/22/16/15/14/11 across 6 fns | `feed_parser.py:857-1136` | **6/10** |
+| 8 | `app.py` is a 5925-line, 109-route god-file spanning ~15 unrelated resource domains | 5925 LOC, 109 routes, MI 0.00 (C) | `app.py` | **7/10** |
+| 9 | Circular dependency between `app.py` and `auth.py`, worked around with a deferred import | 1 site | `auth.py:193` | **6/10** |
+| 10 | `database.py`'s two schema-init functions are enormous but mechanically safe to split | 608 + 446 lines, CC 14 each | `database.py:293`, `database.py:967` | **5/10** |
+| 11 | `_flush_digests` — untestable bin-packing algorithm buried inside I/O | CC 23 (D), 167 lines | `scheduler.py:2699` | **5/10** |
+| 12 | bluesky.py's 4 HTTP-call functions share an undocumented identical shape (new finding, not in the DRY audit) | CC 15/12/12/12 | `bluesky.py` | **5/10** |
+| 13 | `register_submit` — 5 concerns incl. a side-effecting email send inside validation | CC 20 (C), 151 lines | `auth.py:218` | **5/10** |
+| 14 | `scheduler.py` has the highest efferent coupling in the codebase (imports 16 of 25 local modules) | Ce = 16 | `scheduler.py` | **5/10** |
+| 15 | `login_submit` crams two unrelated auth mechanisms behind one branch | CC 11 (C), 81 lines | `auth.py:377` | **4/10** |
+| 16 | `generate_alt_text` — 5 concerns incl. a retry loop wrapping dispatch+parse+validate | CC 18 (C), 113 lines | `alt_text.py:100` | **4/10** |
+| 17 | `_check_feed_with_lease` — CC overstates difficulty; it's a flat guard-clause chain | CC 26 (D), 151 lines | `scheduler.py:361` | **3/10** |
+| 18 | `reader_compose_preview` — CC overstates difficulty; it's null-coalescing chains | CC 20 (C), 56 lines | `app.py:5056` | **3/10** |
+| 19 | `_store_feed_items` — CC overstates difficulty; flat field-by-field mapping, do not refactor | CC 18 (C), 67 lines | `scheduler.py:278` | **1/10** |
+| 20 | `admin_email_save` / `oauth_callback` — CC from independent guard clauses, acceptable as-is | CC 18/16 (C) | `app.py:1551`, `app.py:5820` | **2/10** |
+| 21 | `AuthMiddleware` — large but cohesive; one minor tail duplication between modes | 242 lines, 7 methods | `app.py:300` | **3/10** |
+| 22 | `_validate_payload` — legitimately flat validation, low priority | CC 23 (D) | `import_export.py:154` | **2/10** |
+| 23 | No class in the codebase exceeds 500 lines — the "classes over 500 lines" check is N/A here | max 242 lines | `app.py:300` (`AuthMiddleware`) | **N/A** |
+| 24 | `feed_parser.py` and `settings.py` are the most depended-upon, most stable modules (Ce=0) — cited as a positive baseline, not a defect | Ca 11 / 13, I = 0.00 | `feed_parser.py`, `settings.py` | **N/A (positive)** |
+
+---
+
+## 1. Cyclomatic complexity
+
+Full repo scan (excluding `tests/`): **2,609 blocks analyzed, average CC = A (3.47)**. The distribution is bimodal — the overwhelming majority of functions are simple (A/B grade), concentrated almost entirely in `app.py`, `scheduler.py`, `import_export.py`, `feed_parser.py`, `database.py`, `auth.py`, and `bluesky.py`. 82 functions across the codebase score C-grade (CC≥11) or worse; 12 score D or worse (CC≥21); 3 score F (CC≥41).
+
+### 1.1 `reader_page` — `app.py:2467-2815` (CC 76, grade F, 349 lines) — Importance: 9/10
+
+The single worst function in the codebase, and by a wide margin (next-worst is CC 51). Verified root cause: **roughly half of the 76 branches are a duplicate**. The saved-search unread-count block (`app.py:2699-2775`) reimplements the same filter-op dispatch (`is`/`feed`/`folder`/`in`), the same LIKE-escaping, and the same mute-keyword loop as the main query builder above it (`app.py:2532-2612`) — the mute-keyword loop specifically is duplicated verbatim at both `2604-2612` and `2754-2762`, and the `mutes` query itself runs twice (`2599-2603` and `2706-2710`) for no different input. Max nesting is 5 levels, at `2712-2762` (`with get_db()` → `if saved_searches` → `for s in saved_searches` → `for op, val in s_filters` → nested `if/elif`).
+
+**Fix:**
+```python
+def _reader_where_clause(uid, feed_id, folder_id, q, view, after, mutes) -> tuple[list[str], list]:
+    """WHERE/params shared by the main item list and every saved-search count."""
+    where = ["f.user_id = ?", "f.read_enabled = 1", "f.deleted_at IS NULL"]
+    params: list = [uid]
+    # ... lines 2534-2612 move here verbatim, parameterized instead of closed over ...
+    return where, params
+```
+Call it once for the main list and once per saved search (feed_id=folder_id=None, view driven by the search's own `is:` filter); fetch `mutes` once and pass it in both times.
+
+**Effort: M.** **Post-refactor CC estimate: ~15-20** for the orchestrator once the where-builder (removes ~30), the delivery-badge join, and the saved-search-counts loop (now just calling the shared builder, removes ~15) are pulled out.
+
+### 1.2 `import_data` — `import_export.py:327-511` (CC 51, grade F, 185 lines) — Importance: 7/10
+
+Not deep nesting (max depth 3-4) — this is **breadth complexity**: 4 sequential phases (dedup-feeds `343-359`, dedup-accounts `365-378`, insert-feeds `394-412`, insert-accounts `415-435`, insert-echoes-with-validation `441-498`) each contributing many independent branches, all flattened into one function body. Abstraction mixing: read-only dedup queries sit next to raw INSERT SQL next to per-field validation/clamping next to summary-dict assembly.
+
+**Fix (5 extractions):**
+```python
+def _dedupe_feeds(db, uid, feeds) -> tuple[dict, dict, dict, list]: ...      # lines 339-359
+def _dedupe_accounts(db, uid, accounts_by_section) -> tuple[dict, dict, dict, dict]: ...  # 361-378
+def _insert_new_feeds(db, uid, new_feed_urls, first_feed, feed_oldids, reader_allowed, feed_map) -> None: ...  # 394-412
+def _insert_new_accounts(db, uid, new_account_keys, first_account, account_oldids, account_maps) -> None: ...  # 415-435
+def _normalize_echo_fields(echo: dict) -> dict:
+    """Clamp visibility/filter_mode/delivery_mode to their valid sets."""
+    ...  # lines 468-476, the 3 near-identical if-not-in-valid-set blocks
+def _insert_echoes(db, uid, echoes, feed_map, account_maps) -> tuple[int, int, int]: ...  # 438-498
+```
+`import_data` becomes: validate → dedupe_feeds → dedupe_accounts → (quota check if MULTI) → insert_new_feeds → insert_new_accounts → insert_echoes → build summary dict.
+
+**Effort: M.** **Post-refactor CC estimate: ~5-6** for the orchestrator; `_insert_echoes` carries ~12-15 and is the next candidate if revisited.
+
+### 1.3 `reader_compose` — `app.py:5115-5321` (CC 49, grade F, 207 lines) — Importance: 7/10
+
+Max nesting only 3 levels (`5219-5233`). The complexity is **two full parallel request/response cycles living in one function**: the "enqueue" branch (`5219-5281`) and the "post now" branch (`5284-5321`) each independently validate destinations, build an echo row, and report results, sharing no code. The destination-validation loop (`5159-5174`) is itself a third independent reimplementation of "validate a `type:id` destination reference," a shape that also appears in `add_echo`/`edit_echo` (§1.4) — three call sites for one concept.
+
+**Fix:**
+```python
+def _validate_destination_ref(db, uid: int, dk: str) -> tuple[str, int]:
+    """Parse 'type:id', check it's a real destination type, and confirm ownership."""
+    dest_type, sep, raw_id = dk.partition(":")
+    if not sep or dest_type not in VALID_DEST_TYPES:
+        raise HTTPException(status_code=400, detail=f"Invalid destination: {dk}")
+    destination_id = _filter_int(raw_id)
+    if destination_id is None:
+        raise HTTPException(status_code=400, detail=f"Invalid destination: {dk}")
+    dest_table = DESTINATION_TABLES_BY_TYPE[dest_type]
+    if not db.execute(f"SELECT id FROM {dest_table} WHERE id = ? AND user_id = ?", (destination_id, uid)).fetchone():
+        raise HTTPException(status_code=404, detail=f"Destination not found: {dk}")
+    return dest_type, destination_id
+```
+Then split `reader_compose` itself into `_enqueue_compose(...)` (5219-5281) and `_dispatch_compose_now(...)` (5284-5321), with the parent function reduced to validation + calling one of the two.
+
+**Effort: M.** **Post-refactor CC estimate:** orchestrator ~10-12; each extracted dispatch helper ~8-10.
+
+### 1.4 `add_echo` (`app.py:5395-5507`, CC 29/D, 112 lines) and `edit_echo` (`app.py:5528-5638`, CC 29/D, 111 lines) — Importance: 6/10
+
+These two functions are **~90% identical**: the same 7 validation guards (`5418-5430` vs `5550-5561`) and the exact same 7-arm `if destination_type == "mastodon": destination_id = account_id ... elif ...` chain resolving which form field holds the destination id (`5438-5469`, byte-for-byte reproduced at `5568-5599`). This elif chain alone accounts for ~14 of the 29 CC points in each function, and it's the same "no destination-type registry" root cause flagged in `[DUP §3.10]`. `edit_echo`'s only structural difference is loading the existing row first.
+
+**Fix:**
+```python
+_DEST_FORM_FIELDS = {
+    "mastodon": "account_id", "email": "email_account_id", "bluesky": "bluesky_account_id",
+    "microblog": "microblog_account_id", "matrix": "matrix_account_id",
+    "discord": "discord_account_id", "webhook": "webhook_account_id",
+}
+
+def _resolve_destination_id(destination_type: str, form_values: dict) -> int:
+    field = _DEST_FORM_FIELDS[destination_type]  # KeyError impossible: type already validated
+    destination_id = form_values.get(field)
+    if not destination_id:
+        raise HTTPException(status_code=400, detail=f"{field} required for {destination_type} destination")
+    return destination_id
+```
+Also extract the shared validation prologue (`5418-5435` / `5550-5566`, identical) into `_validate_echo_form(destination_type, visibility, filter_mode, delivery_mode, drip_limit, template, uid, db) -> int` (returns the clamped drip_limit).
+
+**Effort: M** (shared by both functions; do together). **Post-refactor CC estimate:** both drop from 29 to ~8-10.
+
+### 1.5 The 7 `_send_X` destination dispatchers in `scheduler.py` — Importance: 8/10
+
+`[DUP §3.1]` already identified that these 7 functions (mastodon `1126`/CC41, bluesky `1422`/CC27, microblog `1637`/CC18, matrix `1759`/CC24, discord `1964`, webhook `2056`, email `1286`) share a copy-pasted skeleton and proposed 5 shared helpers. Deep read confirms those helpers help but **undercount the real complexity source**: the image-attachment pipeline that each function inlines reaches **5-7 levels of nesting** over 60-100 lines (e.g. `_send_mastodon:1161-1242`, `_send_bluesky:1464-1540`) — `if attach_image → if image_url/raw_urls → if image_result → if type/size valid → if alt_description / elif alt_text.is_enabled → try/except generation`. The DRY audit's proposed `_resolve_alt_text` helper only covers the innermost 2 of those levels.
+
+**Fix — extract one level higher than the DRY audit proposed:**
+```python
+def _attach_platform_image(item, echo, *, allowed_types=None, max_bytes=None) -> tuple[bytes | None, str, str]:
+    """Fetch, validate, and resolve alt text for one image.
+    Returns (blob_bytes_or_None, content_type, alt_text)."""
+    ...
+```
+Bluesky's re-authentication-and-retry-once block (`_send_bluesky:1564-1622`, 3 nested except clauses) is Bluesky-specific — extract separately as `_post_with_reauth_retry(session, account, do_post)`, don't fold it into the shared skeleton.
+
+**Effort: M** (touches the hottest path in the app — posting; needs a full SQLite+Postgres test run before merging, per the project's own review methodology). **Post-refactor CC estimates:** `_send_mastodon` 41→~14-16, `_send_bluesky` 27→~10-12, `_send_matrix` 24→~11-13 (matrix inherently posts text and image as two separate API events — that residual complexity is real domain behavior, not duplication, and shouldn't be eliminated), `_send_microblog` 18→~9-10.
+
+### 1.6 `_flush_queue` — `scheduler.py:2280-2522` (CC 33, grade E, 243 lines) — Importance: 7/10
+
+Max nesting depth 5, at `2476-2478`. Five mixed concerns in one function: SQL claim/lease logic (`2340-2360`), cross-tenant plan-cap math (`2366-2385`), a surprising, easy-to-miss row-migration that backfills a missing `echoes` row for legacy queue entries (`2392-2419`), item-dict hydration (`2421-2448`), and retry-backoff/status-transition bookkeeping (`2450-2522`). **A real bug-adjacent duplication was found here**: the retry-backoff computation `datetime.now(timezone.utc) + timedelta(minutes=new_attempt*10)` plus the same `UPDATE queued_posts SET status='queued'...` statement appears twice verbatim — once at `2479-2486` and again at `2506-2515` (success-then-marked-failed vs. exception branches) — a prime spot for the two copies to silently drift.
+
+**Fix:**
+```python
+def _schedule_retry_or_terminal(db, qp_id, claim_token, row, err_msg: str) -> None:
+    """Unifies the two identical backoff blocks at 2479-2486 and 2506-2515."""
+    new_attempt = row["attempt_count"] + 1
+    if new_attempt < 3:
+        retry_at = (datetime.now(timezone.utc) + timedelta(minutes=new_attempt * 10)).strftime("%Y-%m-%d %H:%M:%S")
+        db.execute(
+            "UPDATE queued_posts SET status='queued', error_message=?, attempt_count=?,"
+            " scheduled_at=?, claim_token=NULL, claimed_at=NULL WHERE id=? AND claim_token=?",
+            (err_msg, new_attempt, retry_at, qp_id, claim_token),
+        )
+    else:
+        db.execute(
+            "UPDATE queued_posts SET status='failed', error_message=?, attempt_count=?"
+            " WHERE id=? AND claim_token=?",
+            (err_msg, new_attempt, qp_id, claim_token),
+        )
+```
+Plus 6 more extractions for the other concerns (`_reclaim_stuck_sending`, `_fetch_due_queue_rows`, `_hourly_post_counts`, `_claim_queue_row`, `_hourly_cap_exceeded`, `_get_or_create_echo`, `_build_item_from_row`) — see full breakdown in the fork evidence; each is a straight-line extraction of an existing contiguous block.
+
+**Effort: M.** **Post-refactor CC estimate: ~10-12.**
+
+### 1.7 feed_parser.py image-extraction cluster — Importance: 6/10 (elevated from a pure-complexity finding — a real bug was found)
+
+`[DUP §2.5]` proposed making the single-result extractors thin wrappers over the list extractors. Deep read **confirms this also fixes a real correctness bug, not just duplication**: `_extract_rss_image` (`932-964`, CC 14) is not actually a subset of `_extract_rss_images` (`857-929`, CC 22) — it independently reimplements the walk with different behavior (merges media_content/media_thumbnail into one loop instead of "thumbnail only if content is empty" per `901-904`, and skips the video/audio filter `_is_image_media` entirely, `879-887`). **A feed entry with a video in `media_content` and an image in `media_thumbnail` yields different results from the single-image extractor vs. the list extractor on the same input today.**
+
+**Fix:** as proposed in `[DUP §2.5]` — make `_extract_rss_image`/`_extract_rss_image_alt`/`_extract_json_feed_image`/`_extract_json_feed_image_alt` thin wrappers (`imgs = _extract_x_images(entry); return imgs[0]["url"] if imgs else None`). This is not purely mechanical here — it changes `_extract_rss_image`'s behavior to match `_extract_rss_images`', which is the *correct* direction, but **needs a regression check**: run `tests/test_feed_parser.py` and `tests/test_feed_image_alt.py` before/after to confirm no test asserts the current (buggy) behavior.
+
+**Effort: S-M.** **Post-refactor CC estimate:** the 4 wrapper functions drop from CC 22/14/15/11 to CC 2 each; total cluster CC drops from ~100 to ~45-50, concentrated entirely in the two canonical list functions (RSS and JSON Feed), which retain their CC because the priority-order walk is genuine, irreducible feature logic.
+
+### 1.8 `database.py`'s two schema-init functions — `init_db_sqlite:293-903` (608 lines, CC 14) and `init_db_postgres:967-1414` (446 lines, CC 14) — Importance: 5/10
+
+Confirmed via direct read: both are **genuinely flat** — 22 sequential `CREATE TABLE IF NOT EXISTS` statements with zero branching each. All of the CC 14 is concentrated in ~4 one-off migration blocks interspersed among the table definitions (a `username` backfill at `310-326`, unique-constraint table-rebuild guards for `email_accounts`/`bluesky_accounts` at `377`/`399`, a `settings.user_id` backfill guard at `439`). This is a low-risk, purely mechanical split.
+
+**Fix:**
+```python
+def _create_accounts_table(db) -> None:
+    db.execute("""CREATE TABLE IF NOT EXISTS accounts (...)""")  # lines 298-308
+
+def _migrate_accounts_username(db) -> None:
+    ...  # lines 310-326 — the one real migration branch for this table
+
+# ... one pair (create + migrate-if-needed) per table, ~26 tiny functions total
+```
+`init_db_sqlite` becomes a flat call list. This is also a stepping stone toward `[DUP §3.2]`'s recommendation of a dialect-agnostic schema spec — splitting per-table first makes a later generator straightforward to build table-by-table.
+
+**Effort: S**, despite the line count — it's copy-paste-and-wrap, not a logic change. **Post-refactor CC: 1** for each orchestrator; each extracted function is CC 1 (pure DDL) or CC 2-4 (migrations).
+
+### 1.9 `register_submit` — `auth.py:218-368` (CC 20, grade C, 151 lines) — Importance: 5/10
+
+Max nesting depth 5 at `321-327`. Five concerns in sequence: form validation (`226-236`), rate-limit check (`243-250`), a DB transaction with embedded early-return HTTP responses (`252-338`), a best-effort side-effect email send **outside** the transaction (`342-360`), and response/cookie construction (`365-368`).
+
+**Fix:**
+```python
+def _validate_registration_form(email: str, password: str, confirm: str) -> list[str]:
+    errors = []
+    if not _EMAIL_RE.match(email):
+        errors.append("Enter a valid email address.")
+    if len(password) < _MIN_PASSWORD_LENGTH:
+        errors.append(f"Password must be at least {_MIN_PASSWORD_LENGTH} characters.")
+    if len(password) > _MAX_PASSWORD_LENGTH:
+        errors.append(f"Password must be at most {_MAX_PASSWORD_LENGTH} characters.")
+    if password != confirm:
+        errors.append("Passwords do not match.")
+    return errors
+
+def _create_user_or_none(db, email, password, trial_end) -> dict | None:
+    """Returns the new user row, or None on a duplicate-email race."""
+    ...  # lines 286-312, catching IntegrityError/UniqueViolation -> return None
+
+def _send_verification_email_best_effort(user_id: int, email: str) -> None:
+    ...  # lines 342-360, already self-contained
+```
+**Effort: S.** **Post-refactor CC estimate: ~10-11** — the remaining branches (duplicate email, bad invite, throttled) are legitimate user-facing early returns, not smell.
+
+### 1.10 `login_submit` — `auth.py:377-457` (CC 11, grade C, 81 lines) — Importance: 4/10
+
+Low CC but **crams two entirely unrelated authentication mechanisms** behind one `if not settings.MULTI` at line 383: single-mode shared-secret token comparison (`383-418`) vs. multi-mode email+password+session lookup (`420-457`). This is mixed responsibility, not deep nesting (nesting is only 3 levels).
+
+**Fix:**
+```python
+def _login_single_mode(request, token: str):
+    ...  # lines 384-418, unchanged
+
+def _login_multi_mode(request, email: str, password: str):
+    ...  # lines 420-457, unchanged
+
+def login_submit(request, email: str = Form(""), password: str = Form(""), token: str = Form("")):
+    if not settings.MULTI:
+        return _login_single_mode(request, token)
+    return _login_multi_mode(request, email, password)
+```
+**Effort: S.** **Post-refactor CC: 2** for the dispatcher; ~6-7 for each mode handler.
+
+### 1.11 `generate_alt_text` — `alt_text.py:100-212` (CC 18, grade C, 113 lines) — Importance: 4/10
+
+Max nesting depth 4 at `187-194`. Five concerns wrapped in a retry loop: settings/config fetch+guard (`109-118`), request-payload construction (`120-136`), SSRF validation gated on `MULTI` (`148-153`), dual-path HTTP dispatch — pinned vs. unpinned client (`159-178`), and defensive response-shape unpacking (`182-194`).
+
+**Fix:**
+```python
+def _build_vision_request(image_bytes: bytes, content_type: str) -> dict: ...   # lines 120-136
+
+def _dispatch_vision_request(endpoint, headers, body):
+    if app_settings.MULTI:
+        return pinned_request("POST", endpoint, timeout=TIMEOUT_SECONDS, headers=headers, json=body)
+    with unpinned_client(timeout=TIMEOUT_SECONDS) as client:
+        return client.post(endpoint, headers=headers, json=body)
+
+def _extract_alt_text(parsed) -> str: ...   # lines 187-194, returns "" on any shape mismatch
+```
+**Effort: S.** **Post-refactor CC estimate: ~9-10** — config guards, the SSRF branch, and retry/exception handling appropriately remain in the orchestrator.
+
+### 1.12 bluesky.py's 4 HTTP-call functions — new finding, not in the DRY audit — Importance: 5/10
+
+Reading `create_session` (`188-222`, CC 10), `refresh_session` (`225-...`, CC 12), `upload_blob` (`420-467`, CC 12), and `create_post` (`470-...`, CC 12) together surfaced a same-file duplication+complexity cluster the earlier DRY audit's destination-modules pass didn't catch (it looked at cross-file HTTP-status duplication in discord/matrix/webhook, not within bluesky.py). All 4 share the identical shape: POST via `pinned_request` in try/except → `BlueskyError`, a status-code ladder (401-or-token-error → `BlueskyAuthError`, ≥400 → `BlueskyError`), `response.json()` in try/except `ValueError`, then field-extraction+validation.
+
+**Fix:**
+```python
+def _bluesky_call(method, url, *, error_context: str, auth_error_on_401=True, **kwargs) -> dict | None:
+    try:
+        response = pinned_request(method, url, **kwargs)
+    except (httpx.RequestError, SSRFError) as exc:
+        raise BlueskyError(f"Could not reach {error_context}") from exc
+    detail = _error_detail(response)
+    if auth_error_on_401 and (response.status_code == 401 or _is_token_error(detail)):
+        raise BlueskyAuthError(f"{error_context} rejected{f' ({detail})' if detail else ''}")
+    if response.status_code >= 400:
+        raise BlueskyError(f"{error_context} failed (HTTP {response.status_code}){f' ({detail})' if detail else ''}")
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise BlueskyError(f"{error_context} returned an invalid response") from exc
+```
+**Effort: S-M.** **Post-refactor CC estimates:** `create_session` 10→~4, `refresh_session` 12→~4, `upload_blob` 12→~5 (keeps type/size pre-checks), `create_post` 12→~5. **Also add this to `audits/CODE_DUPLICATION_AUDIT.md`** as a cross-reference — it was found during this pass, not the original DRY audit.
+
+### 1.13 `resolve_pds` — `bluesky.py:97-167` (CC 15, grade C) — Importance: included in §1.12's area, not separately scored
+
+Nesting depth 3 at `153-159`. Branches into two entirely different network protocols (did:web fetches a well-known JSON document; did:plc queries a directory service) inside one function.
+
+**Fix:**
+```python
+def _fetch_did_document(did: str, handle: str) -> dict: ...      # lines 123-144
+def _pds_from_did_document(doc: dict, handle: str) -> str: ...   # lines 150-161
+```
+**Effort: S.** **Post-refactor CC estimate: ~7-8.**
+
+### 1.14 Functions where CC overstates real difficulty — do not prioritize refactoring these
+
+- **`_store_feed_items`** (`scheduler.py:278-344`, CC 18) — Importance: **1/10**. Flat, linear; no nesting beyond one `if not item_id: continue`. The CC comes almost entirely from ~10 `item.get(x) or ""` fallback expressions. **Recommendation: do not refactor.** Kept in this report specifically as a worked example so the CC metric isn't applied mechanically elsewhere.
+- **`reader_compose_preview`** (`app.py:5056-5110`, CC 20) — Importance: **3/10**. Only 3 real decision points; the rest is 14 `x or ""` null-coalesces and 2 ternaries inside two dict literals. The actual fix is the `_feed_item_to_dict` extraction already covered under §1.3 (this function builds the same dict shape as `reader_compose`); once that's shared, this function's own CC drops to ~4-5 as a side effect.
+- **`_check_feed_with_lease`** (`scheduler.py:361-511`, CC 26) — Importance: **3/10**. Max nesting only 3 levels; most of the CC is 8 sequential, independent early-return guard clauses (paused, no-echoes, fetch-failed, no-items, cursor-uninitialized, etc.) — already about as simple as this branching can be. The one real extraction is the two structurally-identical delivery loops (`454-479` and `493-503`) into one `_deliver_items(feed_id, lease_token, echoes, items, feed_name, *, advance_cursor: bool)`. **Post-refactor estimate: ~16-18** (guard clauses stay).
+- **`admin_email_save`** (`app.py:1551-1601`, CC 18) and **`oauth_callback`** (`app.py:5820-5898`, CC 16) — Importance: **2/10**. Both are flat chains of independent `if <bad input>: return error` guards, max nesting 2. Read top-to-bottom like a checklist; splitting further would hurt readability. `admin_email_save`'s CC will drop by ~4 automatically once `[DUP §3.4]`/`[DUP §3.6]` (admin-guard and error-render helpers) are applied — no standalone action needed here.
+- **`_validate_payload`** (`import_export.py:154-203`, CC 23) — Importance: **2/10**. Three independent `for` loops each with one shallow `if...: raise` guard — legitimately flat validation. Marginal win (~23→~14) available by factoring into `_validate_records(items, kind, id_required=True)`, but low priority.
+
+### 1.15 `_flush_digests` — `scheduler.py:2699-2865` (CC 23, grade D, 167 lines) — Importance: 5/10
+
+Max nesting depth 3. Contains a genuine **bin-packing algorithm** building the digest body under a byte budget with an edge case for a single oversized item (`2738-2778` — the hardest part to read, due to budget arithmetic and a "degenerate case" comment at `2765-2770`), sandwiched between SQL fetch and two different bookkeeping blocks for failure vs. success.
+
+**Fix:**
+```python
+def _pack_digest_body(echo_row, items) -> tuple[str, list, list]:
+    """Pure function: builds (body, sent_items, held_items) under DIGEST_MAX_CHARS.
+    Isolates the size-budget algorithm so it's unit-testable without a DB or send_email."""
+    ...
+
+def _finalize_digest_failure(db, echo_id, sent_items, exc) -> None: ...   # lines 2819-2833
+def _finalize_digest_success(db, echo_id, sent_items) -> None: ...        # lines 2837-2856
+```
+**Effort: S-M.** **Post-refactor CC estimate: ~10-12.** This is the highest-value single extraction in the scheduler cluster after the `_send_X` functions — it turns an algorithm with no isolated test coverage today into a pure function that can get direct unit tests (e.g. "one item exceeds the budget alone" is exactly the kind of edge case that deserves a dedicated test and currently can't get one without spinning up the DB and email layers).
+
+---
+
+## 2. Cognitive complexity
+
+Cyclomatic complexity counts branches; cognitive complexity is about how hard the *reader* has to work, which the manual reads above targeted directly. Cross-cutting cognitive-load patterns found across multiple functions:
+
+- **Nesting depth 5+ recurs in exactly the same shape** (image-attachment pipelines) across `_send_mastodon`, `_send_bluesky`, `_send_matrix`, `_send_microblog` — once a reader learns to parse one, the other three are the same shape with different API calls. This is a case where fixing one function's readability (via extraction) effectively fixes four.
+- **Mixed abstraction levels** — raw SQL sitting beside HTTP-response formatting beside business-rule validation in the same function body — is the dominant driver in `reader_page`, `import_data`, `_flush_queue`, `register_submit`, and `generate_alt_text`. In every one of these, the fix is the same shape: pull the SQL/HTTP/validation into named single-purpose helpers so the orchestrator reads as a list of steps.
+- **No recursive functions were found** anywhere in the non-test codebase (confirmed via the AST walk used for the LOC metrics — no `FunctionDef` node calls its own name in its body across the 515 functions analyzed). Recursion is not a contributor to this codebase's complexity.
+- **Guard-clause chains (flat, low cognitive load despite high CC)** appear in `_check_feed_with_lease`, `admin_email_save`, `oauth_callback`, and `_validate_payload` — these are the functions in §1.14 where the CC score should be discounted.
+- **Two unrelated algorithms gated by one boolean, in the same function** — `login_submit`'s `if not settings.MULTI` split (§1.10) is the clearest example: single-mode and multi-mode auth share a function but not a code path, which is worse for a reader than two short functions plus a 2-line dispatcher.
+
+---
+
+## 3. Lines-of-code metrics
+
+### 3.1 Files over 300 lines
+
+| File | Lines | Note |
+|---|---|---|
+| `app.py` | 5,925 | God-file — see §5.1. MI grade **C (0.00)**, the worst in the repo. |
+| `scheduler.py` | 2,983 | Large but cohesive (single responsibility: feed-poll + destination-dispatch pipeline) — see §5.2. MI grade **C (0.00)**. |
+| `database.py` | 1,414 | Dominated by two enormous-but-flat schema functions (§1.8). MI grade **A (36.58)** — deceptively "acceptable" only because MI rewards low CC; the raw size is still a maintainability cost. |
+| `feed_parser.py` | 1,213 | MI grade **C (8.96)**, second-worst in the repo — driven by the image-extraction cluster (§1.7) and several other C/D-grade functions (`get_backdated_items` CC14, `validate_outbound_url` CC13, `parse_json_feed` CC13). |
+| `auth.py` | 628 | MI grade **A (43.07)** but low within its grade band — `register_submit`/`login_submit` are the drivers (§1.9, §1.10). |
+| `bluesky.py` | 553 | MI grade **A (33.51)**, lowest "A" in the repo — driven by §1.12/§1.13. |
+| `matrix.py` | 547 | MI grade **A (38.94)** — `normalize_room` (CC 11) is its only function over the C-grade threshold; not deep-dived in this pass (lower priority than the destination modules already covered). |
+| `import_export.py` | 511 | MI grade **A (34.38)** — driven entirely by §1.2 and §1.14's `_validate_payload`. |
+| `webhook.py` | 354 | MI grade **A (46.09)** — `parse_headers` (CC14), `build_payload` (CC13), `normalize_webhook_url` (CC11) are its complexity contributors; not deep-dived here (see `[DUP §3.3]` for the naming-collision finding on `normalize_webhook_url`). |
+| `settings.py` | 347 | MI grade **A (59.94)** — `_load_plan_limits` (CC13) is its only notable function. |
+
+Files under 300 lines are not flagged; none showed complexity metrics warranting inclusion.
+
+### 3.2 Functions over 50 lines (69 functions found; top 20 shown, exact via AST)
+
+| Lines | Function | Location |
+|---|---|---|
+| 608 | `init_db_sqlite` | `database.py:293` |
+| 446 | `init_db_postgres` | `database.py:967` |
+| 349 | `reader_page` | `app.py:2467` |
+| 243 | `_flush_queue` | `scheduler.py:2280` |
+| 213 | `_send_bluesky` | `scheduler.py:1422` |
+| 207 | `reader_compose` | `app.py:5115` |
+| 189 | `_send_matrix` | `scheduler.py:1759` |
+| 185 | `import_data` | `import_export.py:327` |
+| 167 | `_flush_digests` | `scheduler.py:2699` |
+| 158 | `_send_mastodon` | `scheduler.py:1126` |
+| 151 | `_check_feed_with_lease` | `scheduler.py:361` |
+| 151 | `register_submit` | `auth.py:218` |
+| 124 | `import_opml` | `app.py:4403` |
+| 120 | `_send_microblog` | `scheduler.py:1637` |
+| 118 | `queue_post_now` | `app.py:1892` |
+| 117 | `_render_and_dispatch` | `scheduler.py:900` |
+| 117 | `dashboard` | `app.py:1183` |
+| 113 | `generate_alt_text` | `alt_text.py:100` |
+| 112 | `add_echo` | `app.py:5395` |
+| 111 | `edit_echo` | `app.py:5528` |
+
+All functions above CC≥18 from §1 also appear in this list — length and branching are correlated here, as expected, with the two schema-init functions in `database.py` as the sole exception (huge but flat, §1.8).
+
+**`queue_post_now`** (`app.py:1892-2009`, CC 22, 118 lines, not separately sectioned above): contains an exact internal duplication — the `INSERT INTO echoes (...)` block is copy-pasted verbatim at `1926-1932` and `1935-1941` (both branches of `if row["echo_id"] ... else` build an echo the same way when none exists). Fix:
+```python
+def _get_or_create_oneshot_echo(db, row, uid, now_utc) -> tuple[int, sqlite3.Row]:
+    if row["echo_id"]:
+        echo = db.execute("SELECT * FROM echoes WHERE id = ?", (row["echo_id"],)).fetchone()
+        if echo:
+            return echo["id"], echo
+    echo_id = db.execute(
+        """INSERT INTO echoes (feed_id, destination_type, destination_id, template,
+                               visibility, attach_image, enabled, one_shot, deleted_at, user_id)
+        VALUES (?, ?, ?, '{{ title }}', ?, ?, 0, 1, ?, ?) RETURNING id""",
+        (row["feed_id"], row["destination_type"], row["destination_id"],
+         row["visibility"] or "public", row["attach_image"], now_utc, uid),
+    ).fetchone()["id"]
+    echo = db.execute("SELECT * FROM echoes WHERE id = ?", (echo_id,)).fetchone()
+    if not row["echo_id"]:
+        db.execute("UPDATE queued_posts SET echo_id = ? WHERE id = ?", (echo_id, row["id"]))
+    return echo_id, echo
+```
+Importance: **4/10**, Effort: **S**. Post-refactor CC estimate: ~14 (the surrounding claim/dispatch/status-update flow is sequential, not nested).
+
+### 3.3 Classes over 500 lines
+
+**None found.** The largest class in the codebase is `AuthMiddleware` (`app.py:300-541`) at 242 lines / 7 methods — well under the 500-line threshold. This codebase is predominantly procedural/functional (module-level functions, not classes), so the "classes over 500 lines" check is **N/A** as a category here. Full class inventory (all classes, largest first): `AuthMiddleware` (242, 7 methods), `RequestIdMiddleware` (59, 1 method), `PinningNetworkBackend` (48, 6 methods, `feed_parser.py:175`), `SecurityHeadersMiddleware` (33, 1 method), `_PinnedTransport` (28, 2 methods), `CappedSandbox` (27, 2 methods), `CSRFOriginMiddleware` (27, 2 methods), `_PgConnection` (17, 5 methods) — every other class in the repo is a small exception type (0-1 methods).
+
+### 3.4 `AuthMiddleware` — `app.py:300-541` (242 lines, 7 methods) — Importance: 3/10
+
+Read in full. **Cohesion is good** — all 7 methods (`dispatch`, `_path_is_routed`, `_token_matches`, `_single`, `_session_user`, `_pending_card`, `_multi`) serve one responsibility (deciding whether/how to admit a request), with comments explaining *why* specific branches exist (e.g. the documented 404-vs-login-redirect fix at `373-377`). Single-mode and multi-mode are genuinely different algorithms sharing helper primitives, not unrelated concerns bolted together — **splitting this into separate classes would relocate complexity, not reduce it.**
+
+One real, minor duplication: `_single`'s tail (`446-456`: not-routed passthrough → Accept-header branch → redirect-or-401) is near-identical to `_multi`'s tail (`532-540`).
+```python
+@staticmethod
+def _unauthenticated_response(request: Request):
+    if not AuthMiddleware._path_is_routed(request):
+        return None  # caller falls through to call_next
+    if "text/html" in request.headers.get("accept", "") and request.method == "GET":
+        return RedirectResponse(url="/login", status_code=302)
+    return JSONResponse({"detail": "Authentication required"}, status_code=401)
+```
+Effort: **S**. Minor CC reduction (~2-3 each in `_single`/`_multi`); not a priority relative to §1's findings.
+
+---
+
+## 4. Coupling metrics
+
+Computed from a full `ast`-based import graph over all 25 local top-level modules (afferent Ca = number of local modules that import this one; efferent Ce = number of local modules this one imports; instability I = Ce/(Ce+Ca), where 0 = maximally stable/depended-upon, 1 = maximally unstable/dependent).
+
+| Module | Ce | Ca | Instability | Note |
+|---|---|---|---|---|
+| `app` | 21 | 1 | 0.95 | Entry point — see caveat below |
+| `scheduler` | 16 | 1 | 0.94 | Highest *internal* efferent coupling — §4.2 |
+| `auth` | 8 | 1 | 0.89 | Ca=1 only because of the circular-import workaround — §4.3 |
+| `oauth` | 4 | 1 | 0.80 | |
+| `import_export` | 3 | 1 | 0.75 | |
+| `alt_text` | 4 | 2 | 0.67 | |
+| `notify` | 2 | 1 | 0.67 | |
+| `email_sender` | 4 | 4 | 0.50 | |
+| `verification` | 2 | 2 | 0.50 | |
+| `webhook` | 2 | 2 | 0.50 | |
+| `logging_setup` | 1 | 1 | 0.50 | |
+| `bluesky`/`discord`/`invites`/`mastodon`/`matrix`/`microblog` | 1 each | 2 each | 0.33 | Uniform shape — each destination module depends only on `feed_parser`, and is depended on only by `app`+`scheduler` |
+| `database` | 2 | 8 | 0.20 | Stable — depended on by 8, depends on only `security`+`settings` |
+| `plans` | 1 | 4 | 0.20 | Stable |
+| `security` | 1 | 9 | 0.10 | Very stable — near the bottom of the dependency graph |
+| `settings` | 0 | 13 | 0.00 | Maximally stable — the most depended-upon module, imports nothing local |
+| `feed_parser` | 0 | 11 | 0.00 | Maximally stable |
+| `template_engine` | 0 | 2 | 0.00 | |
+| `filters` | 0 | 1 | 0.00 | |
+| `utils` | 0 | 0 | 0.00 | New module from the duplication audit; not yet imported anywhere (by design — see `[DUP §6]`) |
+
+**Positive finding (Importance: N/A):** `settings.py` (Ca=13, Ce=0) and `feed_parser.py` (Ca=11, Ce=0) sit at the stable base of the dependency graph and depend on nothing else locally — exactly where foundational modules should sit in a well-factored codebase. `security.py` (Ca=9, Ce=1) is nearly as stable. This is evidence the *low-level* module boundaries are sound even where the high-level ones (below) are not.
+
+### 4.1 Instability caveat for `app.py`
+
+`app.py`'s I=0.95 looks alarming by the textbook formula, but this is an artifact of it being the **process entry point** — nothing is expected to import it (Ca would be 0 in a typical Python web app), so the metric's usual interpretation ("high instability = risky to depend on this, but nothing depends on it so that's fine") actually holds here. **What Ca=1 actually is** is not a normal import — it's the circular-dependency workaround described next.
+
+### 4.2 `scheduler.py` — highest genuine (non-entry-point) efferent coupling — Importance: 5/10
+
+`scheduler.py` imports 16 of the other 24 local modules (`alt_text, bluesky, database, discord, email_sender, feed_parser, filters, mastodon, matrix, microblog, notify, plans, security, settings, template_engine, webhook`) — it is the "orchestrator hub" that knows about every destination type and every cross-cutting concern. This is architecturally consistent with `[DUP §3.1]`'s finding (the 7 `_send_X` functions are the reason for most of these imports — one per destination module) and with §1.5/§1.6 above (the same functions are also the complexity hot spot). **Reducing this coupling is not a separate task from the complexity fixes in §1.5-§1.6** — extracting the shared dispatch skeleton naturally reduces how much destination-specific knowledge lives directly in `scheduler.py`'s top-level namespace, though it will still need to import all 7 destination modules by nature of being the dispatcher.
+
+### 4.3 Circular dependency: `app.py` ↔ `auth.py` — Importance: 6/10
+
+Verified: `app.py` imports from `auth.py` at module load time (top-level, per the import graph). `auth.py` cannot import `app.py` at module level for the same reason, so it works around this with a **deferred, function-local import**:
+```python
+# auth.py:192-195
+def _render_auth(request: Request, template: str, status_code: int = 200, **kwargs):
+    from app import render
+    return render(template, request, status_code=status_code, **kwargs)
+```
+This is the only such site in the codebase (confirmed via `grep -rn "from app import" *.py`). It works, but it's a real architectural smell: `render()` (the templating entry point) living in `app.py` rather than in a module both `app.py` and `auth.py` can import from top-level is *why* the cycle exists. It also means `auth.py` cannot be imported/tested in isolation without `app.py` successfully importing first (both modules load fully at process start today, so this isn't a live bug — but it constrains any future attempt to split `app.py`, which is exactly what §5.1 recommends).
+
+**Fix:** move `render()` (and whatever template-environment setup it depends on) out of `app.py` into `template_engine.py` (which already exists and both `app.py` and `auth.py` could import from without a cycle — `template_engine.py` currently has Ce=0, Ca=2, so it's a safe place to add a dependency). Then `auth.py:193`'s deferred import becomes a normal top-level `from template_engine import render`.
+
+**Effort: S-M** — moving `render()` is likely a small, mechanical change, but **needs verification**: confirm `render()`'s current implementation in `app.py` doesn't reach back into other `app.py`-local state (route table, middleware config) that would reintroduce the cycle. Grep `def render` in `app.py` to check before moving.
+
+---
+
+## 5. Cohesion analysis
+
+### 5.1 `app.py` — low cohesion, a god-file — Importance: 7/10
+
+`app.py` contains **109 route handlers**, **4 middleware classes**, and **159 top-level definitions** in one 5,925-line file. Grouping the 109 routes by top-level URL prefix shows at least 13 largely-independent resource domains living in one file: reader (12 `/api/reader*` routes + `reader_page`/`reader_compose`), feeds (11), settings (5), queue (5), folders (4), echoes (4), 7 separate destination-account CRUD groups (mastodon/email/bluesky/microblog/matrix/discord/webhook — 3 routes each), saved-searches (3), history (2), plus admin (11 routes), auth-adjacent pages (login/register/logout/forgot/reset — 9 routes), and static/legal pages (about/terms/privacy/pricing/howto — 5 routes). This is not "one big module with a clear purpose" (contrast with `scheduler.py`, §5.2) — it's **the union of everything that needs an HTTP route**, which is why it's also the single file responsible for 3 of this report's top-4 worst functions (`reader_page`, `reader_compose`, `add_echo`/`edit_echo`) and the sole file with MI grade C (0.00).
+
+**Fix (structural, not a quick snippet):** split by resource domain into per-area route modules (e.g. `routes_reader.py`, `routes_accounts.py`, `routes_admin.py`, `routes_settings.py`) each exposing an `APIRouter`/route-registration function that `app.py` imports and mounts, keeping only app construction, middleware registration, and cross-cutting helpers (like `render()`, once moved per §4.3) in `app.py` itself. This is the single highest-leverage structural change available in this codebase, but it's large — **Effort: L**, and should be planned as its own project (with the per-function fixes in §1 done first, since a smaller `add_echo`/`edit_echo`/`reader_page` will be much easier to relocate than the current versions).
+
+### 5.2 `scheduler.py` — large but cohesive — contrast case, no action needed
+
+Despite being the second-largest file (2,983 lines, 53 top-level definitions), every one of `scheduler.py`'s functions serves the same responsibility: the scheduled feed-poll → item-store → destination-dispatch → retry/digest/drip pipeline. There is no unrelated concern mixed in (no HTTP routing, no admin logic, no auth). Its high efferent coupling (§4.2) is a *consequence* of legitimately needing to know about every destination type to do its one job, not a symptom of doing multiple jobs. **This module does not need to be split for cohesion reasons** — its problems are the individual function complexity issues in §1.5-§1.6 and §1.15, not its file-level organization.
+
+### 5.3 Destination modules (`bluesky.py`, `discord.py`, `mastodon.py`, `matrix.py`, `microblog.py`, `webhook.py`) — cohesive, uniform, well-bounded
+
+Each of these has an identical coupling shape (Ce=1 [only `feed_parser`], Ca=2 [only `app`+`scheduler`]) and each is focused solely on one platform's API integration. This is the intended design unit boundary in this codebase and it's working — no cohesion concerns found here; the complexity issues found within them (§1.12, §1.13, and `[DUP]`'s findings) are internal-to-the-module duplication/complexity, not misplaced responsibility.
+
+### 5.4 Single-responsibility adherence — summary
+
+Of the 8 largest files, 7 are internally cohesive (single clear responsibility, even where individual functions are too complex): `scheduler.py`, `database.py` (schema + query helpers), `feed_parser.py` (feed fetching/parsing/SSRF-safety), `auth.py` (authentication flows), `bluesky.py`/`matrix.py`/`import_export.py` (each one clear job). **`app.py` is the sole exception** and is respectively the largest file, the file with the worst 3 functions in the report, and the only file with the worst possible MI grade — all three facts point at the same root cause (§5.1), not three separate problems.
+
+---
+
+## Appendix: methodology notes and what was ruled out
+
+- **Recursion:** exactly one recursive function in the non-test codebase, independently verified via an `ast`-based self-call check: the nested `walk(node, current_folder_id, depth)` inside `import_opml` (`app.py:4456-...`, part of the 124-line `import_opml` at `app.py:4403`), which recursively walks OPML `<outline>` nodes with an explicit `depth > 10: return` guard (`4458-4459`) and a `total_outlines > 1000` circuit-breaker (`4464-4465`). This is a legitimate, appropriately-bounded use of recursion for tree-shaped input (OPML folders can nest) — **not a complexity finding**, Importance N/A, no action recommended. Everywhere else in the codebase, "recursive calls" as a cognitive-complexity dimension is N/A.
+- **Switch-statement complexity:** Python has no `switch`/`match`-statement usage in the codebase (the one `grep` hit for `match` is a variable named `match` holding a `re.search()` result at `feed_parser.py:1135`, not a `match` statement — confirmed false positive). This dimension maps onto the `if/elif` chain findings already covered (§1.4's 7-arm destination-type chain, §1.10's mode dispatch, etc.) rather than being a separate category.
+- **radon-measured CC vs. hand-verified post-refactor estimates:** every "post-refactor CC estimate" in this report is a manual estimate from reading the proposed split, not a radon measurement of an actually-refactored function — confirming them precisely requires performing the extraction and re-running `radon cc` on the result. Flagged inline at each estimate rather than stated as measured fact.
+- **Files not deep-dived in this pass** (flagged by radon but below the cutoff used to select fork targets): `matrix.py`'s `normalize_room` (CC11), `discover_base_url` (CC9, B-grade); `webhook.py`'s `parse_headers` (CC14), `build_payload` (CC13), `normalize_webhook_url` (CC11, and see `[DUP §3.3]`); `settings.py`'s `_load_plan_limits` (CC13); `security.py`'s `read_session` (CC13). **Needs verification** if a full sweep is wanted — these are all C-grade (CC 11-20), lower priority than the D/E/F-grade functions this report focused on, but not zero.
+- **Test-file complexity** was excluded from scope (this audit targets production code); a handful of C/D-grade test functions exist (e.g. `tests/test_reader_pagination.py:48` at CC23/D) but are not included in the findings or summary table above.

--- a/docs/reviews/2026-09-08-design-patterns-audit.md
+++ b/docs/reviews/2026-09-08-design-patterns-audit.md
@@ -1,0 +1,358 @@
+# FeedEcho — Design Pattern Usage Audit
+
+**Date:** 2026-09-08
+**Scope:** All Python modules at commit `3dcf392` (v1.49.0), excluding `tests/`. Findings below (including line numbers) are a snapshot as of that commit — see [§ Adoption outcome](#adoption-outcome-2026-09-08-post-audit) at the end for what has since landed on master and how line numbers have shifted.
+**Method:** Direct reads of every module discussed below plus targeted greps to confirm/deny pattern presence (searched for `@dataclass`/`NamedTuple`/`BaseModel`/`TypedDict`, `Protocol`/`ABC`/`abstractmethod`, `lru_cache`/module-level cache dicts, middleware registration, and exception-class import graphs). No pattern below is asserted without a cited line range.
+**Companion documents:** `docs/reviews/2026-09-08-code-duplication-audit.md` and `docs/reviews/2026-09-08-code-complexity-audit.md` (both 2026-09-08) — several findings here are the *pattern* lens on issues those reports already found from the duplication/complexity angle; cross-referenced as `[DUP §x.x]` / `[CX §x.x]`. The duplication audit's own adoption record (its §7) is required reading before acting on any finding below that overlaps its scope — several of its "rejected after full read" entries directly bear on findings here (see the outcome section).
+
+**How to read this report:** GoF/architectural patterns are tools, not obligations — a pattern's *absence* is only a finding when the code pays a real, cited cost for not having it. Several sections below conclude "absent, and that's correct" (Observer, Builder-as-a-class, a payment Strategy). Those are marked **N/A (appropriate)** and are not refactoring recommendations.
+
+---
+
+## Summary
+
+| # | Finding | Category | Verdict | Importance |
+|---|---|---|---|---|
+| 1 | No Strategy/Factory registry for the 7 destination types — dispatch is a hand-copied if/elif chain in 5+ places | Creational + Behavioral | Missing, cheap to add | **9/10** |
+| 2 | No Repository layer — 243 raw `db.execute()` calls directly in `app.py` route handlers, 80 more in `scheduler.py` | Domain | Missing | **8/10** |
+| 3 | 6 destination modules define independent exception hierarchies with no shared base class | Structural (Adapter) | Incomplete | **6/10** |
+| 4 | No DTO/value objects anywhere — zero `@dataclass`/`NamedTuple`/`TypedDict`/Pydantic model in production code | Domain | Missing | **5/10** |
+| 5 | Service layer exists for auth/plans/invites/verification/notify, but is 100% absent for feeds/echoes/7 account types/folders/saved-searches/queue/settings | Domain | Inconsistent | **5/10** |
+| 6 | `_saved_search_counts_cache` (Proxy/cache pattern) invalidated manually at 9 separate call sites | Structural (Proxy) | Fragile implementation | **5/10** |
+| 7 | `test_connection()` is implemented 6 times with the same name/return type but incompatible per-platform argument lists — an informal, not formal, Adapter | Structural (Adapter) | Incomplete | **4/10** |
+| 8 | Single-mode vs. multi-mode auth is a Strategy-shaped problem implemented as inline branching, not swappable strategies | Behavioral (Strategy) | Works, could be cleaner | **4/10** |
+| 9 | No DB connection pooling — a legitimate place for a Proxy pattern | Creational/Structural | Missing (perf, not correctness) | **3/10** |
+| 10 | `_PgConnection` — correctly implemented, self-documented Adapter | Structural (Adapter) | **Correct, no action** | N/A |
+| 11 | Logger configuration — correctly implemented idempotent Singleton | Creational (Singleton) | **Correct, no action** | N/A |
+| 12 | No singleton DB connection — each `get_db()` call opens a fresh connection | Creational (Singleton) | **Correctly absent** | N/A |
+| 13 | Starlette middleware stack — correctly implemented Decorator **and** Chain of Responsibility, deliberately ordered with an explanatory comment | Structural/Behavioral | **Correct, no action** | N/A |
+| 14 | `_route_index()` — well-implemented memoizing Proxy | Structural (Proxy) | **Correct, no action** | N/A |
+| 15 | `queued_posts`/`digest_items`/`drip_items` tables are an implicit, appropriately-simple Command pattern (persisted, deferred-execution work items) | Behavioral (Command) | **Appropriate, no action** | N/A |
+| 16 | No Observer/pub-sub system | Behavioral (Observer) | **Appropriately absent** | N/A |
+| 17 | No payment/Strategy pattern for billing | Behavioral (Strategy) | **Out of repo scope by design** | N/A |
+| 18 | No GoF Builder class anywhere; simple builder *functions* (`build_payload`, `build_embed`, `build_facets`) are used instead | Creational (Builder) | **Appropriate, no action** | N/A |
+
+---
+
+## 1. Creational patterns
+
+### 1.1 Singleton — database connections: correctly **absent** (Importance: N/A, positive finding)
+
+`database.py:140-168`'s `get_db()` is a `@contextmanager` that opens a **fresh connection on every call** — SQLite: `sqlite3.connect(...)` at line 157; Postgres: `_pg_connect()` at line 149 — and closes it in a `finally` block. There is no global/singleton connection object anywhere in the codebase (confirmed: no `global` connection variable, no module-level connection instance).
+
+**This is the correct choice, not a missing pattern.** A singleton shared connection would be actively wrong here: FastAPI/Starlette handles concurrent requests on a thread pool (sync routes) and an event loop (async routes), and SQLite/psycopg connections are not safe to share across concurrent transactions without external locking. If you evaluated this codebase against "should there be a Singleton connection?" the answer is no — confirm this understanding is correct before ever "fixing" it.
+
+**Related, distinct performance concern (not a Singleton problem):** each Postgres connection is opened and torn down per request with no pooling — already flagged as LOW in the project's own `docs/reviews/2026-08-28-kimi-full-repo-review.md` item #33 and again in `[CX summary]`. See §9 below — the correct pattern to add here is a connection-pool **Proxy**, not a Singleton.
+
+### 1.2 Singleton — logger: correctly implemented (Importance: N/A, positive finding)
+
+`logging_setup.py:38-71`'s `setup_logging()` is a textbook idempotent-initialization Singleton: a module-level `_configured` flag (`logging_setup.py:29`) guards against re-configuring the root logger, with an explicit docstring explaining *why* idempotency matters ("repeated TestClient startups in one pytest process don't stack handlers," lines 39-45). It also correctly delegates the actual singleton *registry* to Python's own `logging.getLogger()` machinery rather than reinventing one. No action needed.
+
+### 1.3 Factory / Strategy — missing destination-type registry — Importance: 9/10 (the highest-value finding in this report)
+
+There is no Factory or Strategy object for "the thing that knows how to post to a destination type." Instead, the same 7-way enumeration (`mastodon`/`email`/`bluesky`/`microblog`/`matrix`/`discord`/`webhook`) is hand-copied as **at least 5 independent if/elif or lookup structures**, each already documented as a duplication/complexity problem in its own right, but never previously framed as "this is what a Strategy registry is for":
+
+1. `scheduler.py:946-1008` (`_render_and_dispatch`) — a 62-line if/elif chain dispatching to `_send_mastodon`/`_send_email_echo`/`_send_bluesky`/`_send_microblog`/`_send_matrix`/`_send_discord`/`_send_webhook`. `[CX §1.5]` already flagged this function's CC.
+2. `app.py:5438-5469` and `app.py:5568-5599` (`add_echo`/`edit_echo`) — the same 7-arm elif chain resolving which form field holds the destination id. `[CX §1.4]` already flagged this as ~90% duplicate between the two functions.
+3. `templates/echoes.html:223-235` — a 7-branch Jinja `{% if %}/{% elif %}` mirroring the same enumeration. `[DUP §3.10]`.
+4. `app.py:162-171` (`DESTINATION_TABLES_BY_TYPE`) — a **data-only** registry (type → table name), proving the team already reaches for a dict here; it just never grew into a **behavior** registry (type → handler).
+5. `import_export.py:41-55` (`_ACCOUNTS`) — a separately-maintained fourth enumeration of the same 7 types. `[DUP §3.10]`.
+
+**This is unusually cheap to fix**, because the 7 `_send_X` functions in `scheduler.py` already have (with one exception) **identical signatures** — verified directly:
+```
+_send_mastodon(echo, item, content, account_id, posted_id, claim_token) -> bool
+_send_email_echo(echo, item, content, email_account_id, posted_id, claim_token) -> bool
+_send_bluesky(echo, item, content, account_id, posted_id, claim_token) -> bool
+_send_microblog(echo, item, content, account_id, posted_id, claim_token) -> bool
+_send_matrix(echo, item, content, account_id, posted_id, claim_token) -> bool
+_send_discord(echo, item, content, account_id, posted_id, claim_token) -> bool
+_send_webhook(echo, item, content, feed_name, account_id, posted_id, claim_token) -> bool  # one extra positional arg
+```
+
+**Fix:**
+```python
+# scheduler.py, near the top-level constants
+_DESTINATION_HANDLERS = {
+    "mastodon": _send_mastodon,
+    "email": _send_email_echo,
+    "bluesky": _send_bluesky,
+    "microblog": _send_microblog,
+    "matrix": _send_matrix,
+    "discord": _send_discord,
+}
+
+def _render_and_dispatch(echo, item, content, feed_name, posted_id, claim_token, echo_id):
+    ...  # existing setup (lines 900-945) unchanged
+    handler = _DESTINATION_HANDLERS.get(echo["destination_type"])
+    if handler is None:
+        if echo["destination_type"] == "webhook":
+            return _send_webhook(echo, item, content, feed_name, echo["destination_id"], posted_id, claim_token)
+        return _fail_post(posted_id, claim_token, echo_id, f"Unknown destination type: {echo['destination_type']}")
+    return handler(echo, item, content, echo["destination_id"], posted_id, claim_token)
+```
+(`_send_webhook`'s extra `feed_name` parameter is the one signature outlier — either special-case it as above, or — cleaner — reorder its signature to match the other six, moving `feed_name` out of the positional list into a keyword-only param so all 7 fit one calling convention: `handler(echo, item, content, echo["destination_id"], posted_id, claim_token, feed_name=feed_name)` with the other 6 functions accepting `**_ignored` or an explicit unused `feed_name=None` — recommend the signature-alignment approach since it removes the special case entirely.)
+
+Once `_DESTINATION_HANDLERS` exists as the canonical type→behavior registry, it can also back `DESTINATION_TABLES_BY_TYPE` (already exists, just needs handlers added as a second field) and give `import_export.py`'s `_ACCOUNTS` and the `add_echo`/`edit_echo` elif chains one place to import from instead of five independent lists to keep in sync.
+
+**Effort: M** (the registry itself is a 10-line addition; the payoff comes from also migrating `add_echo`/`edit_echo` and `import_export.py` onto it, which `[CX §1.4]` and `[DUP §3.10]` already scoped as separate M-effort tickets — this finding says "do them as one unified registry, not four independent fixes").
+
+### 1.4 Builder — no GoF Builder class; simple builder *functions* used instead (Importance: N/A, appropriate)
+
+The codebase constructs several non-trivial objects — Discord embeds (`discord.py`'s `build_embed`, CC 7 per `[CX]`), webhook JSON payloads (`webhook.py`'s `build_payload`, CC 13), Bluesky rich-text facets (`bluesky.py`'s `build_facets`, CC 8), and digest email bodies (the size-budget algorithm inside `_flush_digests`, `scheduler.py:2699-2865`, which `[CX §1.15]` recommends extracting as a pure `_pack_digest_body` function). None of these use a stateful, chainable Builder class (`.with_x().with_y().build()`).
+
+**This is the right call, not a gap.** Every one of these objects is built from a fixed, known set of inputs in one pass — there's no scenario in this codebase where construction steps are optional, reorderable, or need to be assembled incrementally across multiple call sites. A GoF Builder earns its complexity when a class has many optional constructor parameters or when the same construction process needs to yield different representations; none of that applies here. A plain function that takes the needed inputs and returns the finished object is the simpler, correct choice. **No refactoring recommended.**
+
+---
+
+## 2. Structural patterns
+
+### 2.1 Adapter — `_PgConnection` (`database.py:108-124`) — correctly implemented (Importance: N/A, positive finding)
+
+Self-documented in its own docstring: *"Thin adapter over psycopg3 so callers keep writing `db.execute(sql, ?)`."* It translates psycopg3's connection interface to look like sqlite3's (`execute`/`commit`/`rollback`/`close`), including running SQL text through `qmark()` (`database.py:25`) to convert `?`-style placeholders — the one thing sqlite3 and psycopg don't agree on. This is exactly what an Adapter is for, correctly scoped to the one interface gap that actually exists between the two drivers. No action needed.
+
+### 2.2 Adapter — destination modules: informal, not formal (Importance: 4/10)
+
+Six destination modules (`bluesky.py`, `discord.py`, `mastodon.py`, `matrix.py`, `microblog.py`, `webhook.py`) each expose a `test_connection(...)` function with the same name and the same return contract (`tuple[bool, str]`), confirmed by direct grep:
+```
+bluesky.py:536   def test_connection(handle: str, app_password: str) -> tuple[bool, str]:
+discord.py:290   def test_connection(webhook_url: str) -> tuple[bool, str]:
+mastodon.py:123  def test_connection(instance: str, access_token: str) -> tuple[bool, str]:
+matrix.py:523    def test_connection(...) -> tuple[bool, str]:
+microblog.py:209 def test_connection(token: str) -> tuple[bool, str]:
+webhook.py:317   def test_connection(url: str, headers: dict[str, str]) -> tuple[bool, str]:
+```
+This is an Adapter pattern **by naming convention only** — each function takes different, credential-shape-specific positional arguments, so nothing can call `test_connection` uniformly across destination types without already knowing, per type, which fields to unpack from the account row. Contrast with `scheduler.py`'s `_send_X` functions (§1.3), which already *are* uniform on `(echo, item, content, account_id, posted_id, claim_token)` — the inconsistency is specifically in the `test_connection` family, which is exactly the set of functions `app.py`'s 6 `test_*_account` routes call (`[DUP §1.4]` cluster 6 already found these routes ~85% duplicate for this reason).
+
+**Fix — align on the account-row shape already used elsewhere:**
+```python
+# each module, e.g. discord.py:
+def test_connection(account: dict) -> tuple[bool, str]:
+    return _test_connection_impl(account["webhook_url"])
+```
+Or, more directly useful given `zero formal interface exists today`, declare the shared contract explicitly with `typing.Protocol` (confirmed via grep: `Protocol`/`ABC`/`abstractmethod` do not appear anywhere in production code — the one `Protocol` grep hit in `bluesky.py` is the AT Protocol, not `typing.Protocol`):
+```python
+# a new module, e.g. destinations.py, or utils.py
+from typing import Protocol
+
+class DestinationAdapter(Protocol):
+    def test_connection(self, account: dict) -> tuple[bool, str]: ...
+    def send(self, echo, item: dict, content: str, account_id: int, posted_id: int, claim_token: str) -> bool: ...
+```
+Modules don't need to literally implement a class for `Protocol` to add value — it's structural typing, so the existing module-level functions can be wrapped in a small adapter object per destination that satisfies the Protocol, giving `app.py`'s test-account routes and `scheduler.py`'s dispatch (§1.3) one typed contract instead of two separately-inconsistent conventions.
+
+**Effort: M** — touches 6 modules' public signatures plus the `app.py` call sites already identified in `[DUP §1.4]` cluster 6.
+
+### 2.3 Adapter completeness — no shared exception base class across destination modules (Importance: 6/10)
+
+Each destination module defines its own independent exception hierarchy: `BlueskyError`/`BlueskyAuthError` (`bluesky.py:38,42`), `MicroblogError`/`MicroblogAuthError` (`microblog.py:31,35`), `MatrixError`/`MatrixAuthError`/`MatrixPermissionError` (`matrix.py:69,73,77`), `DiscordError`/`DiscordAuthError`/`DiscordNotFoundError`/`DiscordBadRequestError` (`discord.py:61,80,84,88`), `WebhookError`/`WebhookAuthError`/`WebhookNotFoundError`/`WebhookRejectedError` (`webhook.py:62,77,81,85`). The naming *convention* is consistent (translating each platform's raw errors into an Auth/NotFound/RateLimit/Rejected vocabulary is exactly what an Adapter should do) — but **there is no shared base class**, confirmed by reading `scheduler.py`'s imports (`scheduler.py:29-77`): it imports all ~14 of these exception names individually, with no common ancestor to catch generically.
+
+This is precisely why `[DUP §3.1]`'s "3-tier exception ladder (AuthError→permanent fail, DestinationError→fail with message, bare Exception→generic fail)" has to be **re-implemented per destination module** instead of written once — Python's `except` can't catch "any destination's auth error" without a shared base to catch.
+
+**Fix:**
+```python
+# a new module, e.g. destination_errors.py, or add to utils.py
+class DestinationError(Exception):
+    """Base for all destination-adapter failures; catch this for the generic fail path."""
+
+class DestinationAuthError(DestinationError):
+    """Credentials rejected — permanent failure, no point retrying."""
+
+class DestinationNotFoundError(DestinationError):
+    """Target (channel/room/blog/webhook) no longer exists."""
+
+class DestinationRateLimitError(DestinationError):
+    """Caller should back off; carries retry_after where known."""
+    def __init__(self, message: str, retry_after: float | None = None):
+        super().__init__(message)
+        self.retry_after = retry_after
+```
+Then each module's existing exception becomes `class BlueskyError(DestinationError): ...`, `class BlueskyAuthError(BlueskyError, DestinationAuthError): ...` (multiple inheritance keeps each module's own catch sites working unchanged while adding the shared ancestor). `scheduler.py`'s 3-tier exception ladder can then be written once as a shared helper instead of once per `_send_X` function.
+
+**Effort: M** — the exception class changes themselves are small and backward-compatible (multiple inheritance means existing `except BlueskyAuthError` call sites keep working), but validating the ladder consolidation needs the full test suite (SQLite + Postgres) per the project's own methodology.
+
+### 2.4 Facade — `_render_and_dispatch` is an implicit Facade; quality follows §1.3's fix
+
+`scheduler.py:900-1018` (`_render_and_dispatch`) is the single entry point every caller uses to post an item without knowing which of the 7 destination modules is involved — that's a Facade, and it's the right shape (one function, hides 7 subsystems). Its internals are exactly the if/elif chain from §1.3; fixing that dispatch mechanism does not change the Facade's boundary, only its implementation. No separate action beyond §1.3.
+
+### 2.5 Facade absent between HTTP routes and the database — see §4.1 (Domain: Repository)
+
+There is no Facade/Service layer standing between `app.py`'s route handlers and raw SQL for the CRUD-heavy domains (feeds, echoes, the 7 account types, folders, saved searches, queue, settings). This is really a Repository/Service-layer gap rather than a Facade gap in the classic sense (a Facade simplifies a complex subsystem; here there's no subsystem at all standing between the route and the table) — covered in full at §4.1/§4.2 to avoid double-counting the same evidence under two names.
+
+### 2.6 Decorator (and Chain of Responsibility) — Starlette middleware stack: correctly implemented (Importance: N/A, positive finding)
+
+`app.py:728-733` registers 4 middleware classes:
+```python
+app.add_middleware(AuthMiddleware)
+app.add_middleware(CSRFOriginMiddleware)
+app.add_middleware(SecurityHeadersMiddleware)
+# Outermost: request-id threading + access logging wraps everything.
+app.add_middleware(RequestIdMiddleware)
+```
+Each middleware (`BaseHTTPMiddleware` subclass) wraps `call_next` and can short-circuit or pass through — textbook Decorator, and simultaneously textbook Chain of Responsibility (each link decides whether to handle the request itself or defer to the next). Starlette's `add_middleware` builds the stack in reverse call order (last-added = outermost), and the comment at line 732 shows the team understands and relies on this: request flow is `RequestIdMiddleware → SecurityHeadersMiddleware → CSRFOriginMiddleware → AuthMiddleware → route`. That ordering is sound — request-id is assigned before anything else can log, security headers wrap every response including ones from inner failures, and origin/CSRF checks happen before spending effort on authentication. **No action needed**, cited here only because the task asked to evaluate Decorator/middleware explicitly and it deserves a clean bill of health.
+
+### 2.7 Proxy — `_route_index()` (`app.py:207-236`) — well-implemented memoizing Proxy (Importance: N/A, positive finding)
+
+Caches the split of literal vs. parameterized routes, keyed by `id(app)` and invalidated by comparing `len(routes)` against the cached length (`app.py:214`) — a correct, self-contained invalidation check with no external call sites needing to remember to bust it. Well-commented on *why* (`app.py:202-206`): route-table changes only happen once at startup (`billing.mount`), so length-based invalidation is sufficient and cheap. **No action needed** — cited as the positive contrast to §2.8.
+
+### 2.8 Proxy — `_saved_search_counts_cache` (`app.py:2394`) — functionally correct, fragile invalidation (Importance: 5/10)
+
+A 60-second, `max_item_id`-keyed cache for saved-search unread counts (`app.py:2701-2775`, confirmed by direct read): `if cached and cached[0] == max_item_id and (now_time - cached[1]) < 60: use cached`. The invalidation *logic* is sound (a cheap version-stamp plus a time bound), but unlike §2.7, invalidation is **not self-contained** — it additionally relies on `_saved_search_counts_cache.pop(uid, None)` being called at every mutation site, and that call is duplicated **9 times** across the file: `app.py:3061, 4069, 4104, 4127, 4785, 4802, 4858, 4886, 4914` (confirmed by grep). Any future route that mutates saved searches, feeds, or read-state and forgets to add a 10th `.pop()` call produces stale counts silently — not a crash, just wrong numbers, which is a worse failure mode because nothing will flag it.
+
+**Fix:** wrap the cache in a tiny class so invalidation is one method instead of a copy-pasted literal:
+```python
+class _SavedSearchCountsCache:
+    def __init__(self):
+        self._store: dict[int, tuple[int, float, dict[int, int]]] = {}
+
+    def get(self, uid: int, max_item_id: int, now: float, ttl: int = 60):
+        cached = self._store.get(uid)
+        if cached and cached[0] == max_item_id and (now - cached[1]) < ttl:
+            return cached[2]
+        return None
+
+    def set(self, uid: int, max_item_id: int, now: float, counts: dict[int, int]) -> None:
+        self._store[uid] = (max_item_id, now, counts)
+
+    def invalidate(self, uid: int) -> None:
+        self._store.pop(uid, None)
+
+_saved_search_counts_cache = _SavedSearchCountsCache()
+```
+This doesn't reduce the 9 call sites that must remember to invalidate — that's inherent to write-invalidated caching — but it does mean each call site reads `_saved_search_counts_cache.invalidate(uid)` (one obvious name to grep for when adding a new mutation route) instead of a bare `.pop(uid, None)` that looks like ordinary dict housekeeping and is easy to miss when reviewing a diff.
+
+**Effort: S.**
+
+### 2.9 Proxy — no database connection pooling (Importance: 3/10)
+
+Every `get_db()` call opens and tears down a connection (§1.1). For SQLite this is cheap (local file, WAL mode); for the hosted Postgres path this is a real per-request latency cost, already flagged as LOW in the project's prior review. A connection pool (e.g. `psycopg_pool.ConnectionPool`) is a legitimate Proxy pattern application here — it would sit behind `_pg_connect()` and hand out pooled connections transparently, with `get_db()`'s call sites unchanged. **Not urgent** (correctness is unaffected; this is a latency/scale concern), but flagged since the audit explicitly asks about Proxy/caching and this is the one clear gap in that category with an established, low-risk library solution. **Effort: S-M**, needs a decision on pool sizing and idle-connection lifetime before deploying, not just a code change.
+
+---
+
+## 3. Behavioral patterns
+
+### 3.1 Strategy — destination dispatch — see §1.3 (Creational and Behavioral overlap)
+
+The `_render_and_dispatch` if/elif chain (§1.3) is simultaneously a missing Factory (creating the right handler) and a missing Strategy (selecting the right posting algorithm) — GoF treats these as separate patterns but the fix is the same dict-based registry either way. Not re-scored here to avoid double-counting; see §1.3 for the importance rating and fix.
+
+### 3.2 Strategy — auth mode (single vs. multi-tenant) — Importance: 4/10
+
+`auth.py:377-457` (`login_submit`) and `app.py:300-541` (`AuthMiddleware`, specifically `_single` at line 426 and `_multi` at line 505) both branch on `settings.MULTI` to run one of two **entirely different authentication algorithms** (shared-secret token comparison vs. email+password+session) inside one function/class rather than as two swappable strategy implementations. `[CX §1.10]` already recommends splitting `login_submit` into `_login_single_mode`/`_login_multi_mode` behind a 2-line dispatcher — that fix is exactly "extract the two strategies out of the branch," so this finding is the pattern-language framing of the same fix already scoped there, not an additional one. `AuthMiddleware`'s `_single`/`_multi` split (`[CX §3.4]`) is **already implemented as separate methods**, closer to Strategy already — the remaining gap is that `login_submit` (the route handler) hasn't been split the same way its middleware counterpart has.
+
+**Note on whether formal Strategy classes are warranted:** given there are only ever two modes, selected once at process startup from a config flag (not swapped at runtime per-request), function-level extraction (as `[CX §1.10]` recommends) is sufficient — introducing `AuthStrategy` classes with a common interface would be over-engineering for a boolean that never changes after startup. **Recommendation: apply `[CX §1.10]`'s fix; no additional class hierarchy needed.**
+
+### 3.3 Chain of Responsibility — middleware — see §2.6 (positive, no action)
+
+### 3.4 Chain of Responsibility — guard-clause validation chains — appropriate as-is (Importance: N/A)
+
+`[CX §1.14]` already identified that `admin_email_save`, `oauth_callback`, and `_check_feed_with_lease` implement validation as flat chains of independent early-return guard clauses. This is Chain-of-Responsibility *in spirit* (each check either rejects or passes through) implemented as straight-line code rather than as a linked list of handler objects — which is the right call at this scale (a handful of fixed, non-reorderable checks per function). A real CoR object chain would only pay for itself if the set of checks needed to be dynamically composed or reordered at runtime, which none of these do. **No action needed** — cited to close out the CoR evaluation the task asked for, distinct from the middleware finding.
+
+### 3.5 Observer — absent, and appropriately so (Importance: N/A)
+
+`notify.py`'s `record_failure`/`record_success` (`notify.py`, imported into `scheduler.py:78-83`) are called directly and imperatively wherever a post succeeds or fails — there is no event bus, no subscriber list, no `Observable`/`EventEmitter` abstraction anywhere in the codebase (confirmed: no such class or pattern found). Every "thing that happens when a post fails" (record the failure count, maybe send a notification email) is a fixed, small, known set of side effects called directly from `_fail_post`/`_update_post`. **Introducing a pub/sub Observer here would be premature abstraction** — it would pay off if third-party plugins or a growing list of unrelated side effects needed to hook into post-success/failure without `scheduler.py` knowing about them in advance, but nothing in the current codebase or its documented roadma indicates that need. **No action recommended.**
+
+### 3.6 Command — the queue tables are an appropriate, implicit Command pattern (Importance: N/A, positive finding)
+
+`queued_posts`, `digest_items`, and `drip_items` (schema in `database.py`, populated by `scheduler.py`'s `_queue_for_digest`/`_queue_for_drip`/queue-related functions) are, in effect, serialized Command objects: each row captures "post this item to this destination" as data, to be executed later by `_flush_queue`/`_flush_digests`/`_flush_drips`. This achieves everything a formal `Command` class hierarchy (`execute()`, `undo()`, command history) would provide for this use case — deferred execution, retry, and persistence across process restarts — without the overhead of an object hierarchy, because the "commands" here are homogeneous (always "deliver this item") rather than needing polymorphic `execute()` implementations. **This is the right level of abstraction for a single-process background scheduler** (this is not Celery/a distributed task queue with heterogeneous job types, where a formal Command class would earn its keep). **No action recommended.**
+
+### 3.7 Payment/billing Strategy — out of repo scope by design (Importance: N/A)
+
+Verified via `settings.py:231-239`: *"The actual payment routes (`/api/billing/*`) are NOT part of this repo — the hosted deployment mounts them from its private billing module — so this flag only toggles the front-end seam and never implies Stripe here."* `BILLING_ENABLED` (`settings.py:239`) is a pure feature-flag seam, not a payment Strategy implementation, and isn't meant to be one. **There is nothing to evaluate here** — the task's mention of "payment processing" as a Strategy-pattern example doesn't apply to this codebase; note this explicitly rather than inventing a finding to fill the category.
+
+---
+
+## 4. Domain patterns
+
+### 4.1 Repository pattern — absent — Importance: 8/10
+
+Quantified via direct grep of `.execute(` call sites: `app.py` contains **243** raw SQL execute calls directly inside route handlers; `scheduler.py` contains 80; `import_export.py` 12; `notify.py` 9; `verification.py` 7; `invites.py`/`oauth.py` 5 each; `auth.py` 8. `database.py` — the one module that could plausibly be a Repository layer — exposes **no entity-level CRUD functions** (no `get_feed_by_id`, `create_echo`, `update_account`, etc.); its actual top-level functions are `dialect()`, `qmark()`, `as_utc_naive()`/`timestamp_str()`, `get_db()`, schema/migration helpers (`_column_names`, `_has_unique_on`, `_add_column_if_missing`, `_dedupe_discord_webhook_hashes`), one specific utility (`prune_feed_items`), and the two schema-init functions. Every route handler in `app.py` writes and executes its own SQL directly against `feeds`/`echoes`/`accounts`/`bluesky_accounts`/etc.
+
+This is the domain-layer restatement of `[CX §5.1]`'s "app.py is a 5,925-line god-file" finding — the *reason* every route handler is long and tangled with SQL is that there is no layer absorbing that SQL on their behalf.
+
+**Fix (illustrative — this is a large, structural change, not a snippet-sized one):**
+```python
+# a new module, e.g. repositories/feeds.py
+def get_feed(db, uid: int, feed_id: int) -> dict | None:
+    return db.execute(
+        "SELECT * FROM feeds WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+        (feed_id, uid),
+    ).fetchone()
+
+def list_feeds(db, uid: int) -> list[dict]:
+    return db.execute(
+        "SELECT * FROM feeds WHERE user_id = ? AND deleted_at IS NULL ORDER BY name",
+        (uid,),
+    ).fetchall()
+
+def soft_delete_feed(db, uid: int, feed_id: int, now: str) -> None:
+    db.execute(
+        "UPDATE feeds SET deleted_at = ? WHERE id = ? AND user_id = ?",
+        (now, feed_id, uid),
+    )
+```
+Route handlers then call `feeds.get_feed(db, uid, feed_id)` instead of inlining the SQL. This also directly resolves the exact-duplicate SQL bug `[DUP §1.1]` found (Bluesky/Micro.blog delete routes hand-rolling `_dependent_echo_count`'s query) — with a Repository layer, that duplication is structurally impossible because there's only one place the query could live.
+
+**Effort: L.** This is the single largest structural recommendation across all three audits and should be planned as its own project, most naturally *after* `[CX §5.1]`'s route-module split (a smaller, already-modularized `app.py` makes it much easier to introduce a repository per domain incrementally, one route module at a time, rather than as one big-bang rewrite).
+
+### 4.2 Service layer — present for some domains, absent for others — Importance: 5/10
+
+`auth.py`, `plans.py`, `invites.py`, `verification.py`, and `notify.py` already function as thin service modules: they encapsulate business rules (password validation, plan-limit checks, invite consumption, token verification, failure-notification thresholds) separately from `app.py`'s routes, and `app.py` calls into them rather than reimplementing the logic inline. This is a real, working partial Service Layer.
+
+**The gap:** every CRUD-heavy domain — feeds, echoes, the 7 destination-account types, folders, saved searches, the post queue, and per-user settings — has **zero** service-layer separation; all of their business logic (validation, ownership checks, cap enforcement) is inlined directly in the `app.py` route handlers alongside the SQL (§4.1). This inconsistency means a reader has to know, module by module, whether a given piece of logic lives in a service function or is inlined in the route — there's no single rule to follow.
+
+**Fix:** as domains are migrated onto the Repository layer (§4.1), pull their validation/business-rule code into a matching service function in the same pass (e.g. `services/echoes.py` housing `_validate_destination_ref`/`_resolve_destination_id` from `[CX §1.3]`/`[CX §1.4]`, calling into `repositories/echoes.py` for persistence) — don't do the repository and service extractions as two separate passes over the same code.
+
+**Effort: L** (bundled with §4.1's effort, not additive).
+
+### 4.3 DTO / value objects — absent — Importance: 5/10
+
+Confirmed via repo-wide grep: **zero** occurrences of `@dataclass`, `NamedTuple`, `TypedDict`, or `BaseModel` (Pydantic) in production code. Every domain concept — an echo, a feed, an account, a feed item — is passed around as a raw `sqlite3.Row` (or `dict` for `_PgConnection`'s `dict_row` factory) with no static shape guarantee. This is felt most acutely at exactly the boundary §1.3 recommends formalizing: `_send_X(echo, item, content, account_id, posted_id, claim_token)` — a reader (or a static type checker) has no way to know what keys `echo`/`item` are expected to carry without reading the function body or tracing back to the `SELECT *` that produced the row.
+
+**This is not a blanket "add dataclasses everywhere" recommendation** — for a codebase this size, converting every `SELECT` result to a full domain class would be a large mechanical change for a benefit that's mostly about IDE/type-checker ergonomics rather than fixing a live bug. The **targeted** recommendation is to add lightweight `TypedDict`s exactly where cross-function/cross-module contracts already exist informally, starting with the dispatch boundary from §1.3:
+```python
+from typing import TypedDict
+
+class FeedItem(TypedDict, total=False):
+    id: str
+    title: str
+    content: str
+    summary: str
+    published_at: str
+    image_url: str
+    # ... remaining known keys from feed_parser.py's item dicts
+```
+`TypedDict` costs nothing at runtime (pure static-typing sugar — no behavior change, no migration risk) and can be introduced incrementally, function-signature by function-signature, without touching how rows are actually fetched. **Effort: S per boundary** (start with the `_send_X`/`_render_and_dispatch` boundary alongside §1.3's registry fix, since both changes touch the same function signatures at the same time).
+
+### 4.4 Domain model — anemic, and mostly appropriately so — Importance: not separately scored (folds into §4.1-§4.3)
+
+Business rules (`plans.py`'s limit checks, `scheduler.py`'s `_drip_limit`/`_drip_applies`/`_drip_rate`, the digest-packing algorithm inside `_flush_digests`) are free functions operating on raw dicts/Rows rather than methods on domain objects (an "Echo" class with a `.drip_limit()` method, etc.). For a codebase of this size and shape (a handful of business rules, not a rich domain with dozens of interacting entities), an anemic-model-plus-free-functions design is a **reasonable, appropriate choice** — introducing full DDD-style entities would be over-engineering unless the team has concrete plans to grow the business-rule surface significantly. The parts of this that are worth improving are already captured more precisely above: give the data flowing between functions a typed shape (§4.3) and give the persistence a proper seam (§4.1) — those two changes get most of the practical benefit of "a domain model" without requiring a rewrite into classes.
+
+---
+
+## Appendix: what was checked and ruled out without a separate section
+
+- **Prototype pattern:** not applicable to this codebase — no object cloning/copying use case was found (checked via grep for `copy.deepcopy`/`__copy__`/`clone` — none found in production code beyond routine dict copies). Not scored as a finding; there is no evidence this pattern is needed anywhere.
+- **Visitor pattern:** not applicable — no heterogeneous object-tree traversal exists that would benefit from double-dispatch (the closest candidate, OPML import's recursive `walk()` at `app.py:4456`, per `[CX Appendix]`, operates on a single homogeneous node shape and doesn't need it).
+- **Mediator pattern:** `_render_and_dispatch` (§2.4) already serves as a lightweight mediator between `scheduler.py`'s flush functions and the 7 destination modules; not a gap once §1.3's registry fix lands.
+- **Interpreter pattern:** the saved-search query mini-language (`_parse_reader_query`, referenced in `[CX §1.1]`'s `reader_page` analysis) is a plausible Interpreter-pattern candidate, but a shallow read shows it's a simple token-splitter, not a grammar needing recursive interpretation — **needs verification** if a deeper look is wanted; not read in full for this audit.
+
+---
+
+## Adoption outcome (2026-09-08, post-audit)
+
+Between this audit's initial pass and implementation, master moved ~30 commits (v1.49.0 → v1.50.1) on an unrelated, independently-run adoption of the companion duplication audit (`docs/reviews/2026-09-08-code-duplication-audit.md`, its own §7). That work already extracted `scheduler.py`'s shared destination-dispatch *skeleton* (`_destination_account`/`_echo_attach_image`/`_resolve_alt_text`/`_guard_claim`/`_finalize_success`) — re-verified before starting this work that it did **not** touch the if/elif dispatch chain itself (§1.3 here remained live) or add any exception base classes (§2.3 remained live). All findings below were re-confirmed against current file content (not assumed from the original snapshot) before implementation.
+
+**Landed (this PR):**
+- **§1.3** (destination-dispatch registry): `scheduler.py` — `_DESTINATION_HANDLERS` dict maps 6 of 7 destination types to their `_send_X` function (all share the same signature); `webhook` stays a special case ahead of the dict lookup since it alone needs `feed_name`. `_render_and_dispatch`'s 62-line if/elif chain is now ~10 lines. Zero behavior change — same functions, same call order, same fallback to `_fail_post` for an unknown type.
+- **§2.3** (shared exception base classes): added `DestinationError`/`DestinationAuthError`/`DestinationNotFoundError`/`DestinationRateLimitError` to `utils.py`. Each of the 5 destination modules' existing exception classes (bluesky/discord/matrix/microblog/webhook) now additionally inherit the matching shared base via multiple inheritance — verified every resulting MRO resolves cleanly and that instance attributes set in existing custom `__init__`s (e.g. `DiscordRateLimitError.retry_after`) are unaffected. Every pre-existing `except BlueskyAuthError`-style call site keeps working unchanged; this is purely additive. One deliberate judgment call beyond the audit's original text: `MatrixPermissionError` was folded into `DestinationAuthError` (not left orphaned) after confirming in `scheduler.py` that it's already handled identically to `MatrixAuthError` (both `permanent=True`, non-retryable) — `DestinationAuthError`'s docstring was broadened from "credentials rejected" to "rejected credentials or insufficient permission" to make that inclusion honest.
+- **§4.3** (TypedDict at the dispatch boundary): added `FeedItem` (`TypedDict, total=False`) to `utils.py`, built from `feed_parser.py`'s actual `parse_rss_feed`/`parse_json_feed` item-dict keys (verified directly, not the field names guessed in this document's original §4.3 snippet — e.g. the real key is `date`, not `published_at`). Applied as the type of every `item: dict` parameter in `scheduler.py` (14 sites). `total=False` and a docstring caveat because a backdated/drip-redelivered item reconstructed from the `feed_items` table is not verified to carry every key the fresh parse-time dict does. Zero runtime behavior change (`from __future__ import annotations` means annotations are never evaluated at runtime; `item["key"]` access is identical for `dict` and `TypedDict`).
+- **§2.8** (`_saved_search_counts_cache`): wrapped the bare module-level dict in a small `_SavedSearchCountsCache` class (`.get(uid, max_item_id, now)` / `.set(...)` / `.invalidate(uid)`) in `app.py`, preserving the exact same version-stamp-plus-60s-TTL invalidation logic. All 9 `.pop(uid, None)` call sites (confirmed still 9, unchanged from the original audit's count) now read `.invalidate(uid)`.
+- **§3.2** (auth-mode Strategy split, `login_submit`): split into `_login_single_mode(request, token)` and `_login_multi_mode(request, email, password)` behind a 2-line dispatcher in `auth.py`, exactly as this audit and `[CX §1.10]` both recommended. The public `login_submit(request, email, password, token)` signature is unchanged, so `app.py`'s route wrapper (which calls it by keyword) required no changes.
+
+**Reconsidered, not implemented:**
+- **§2.2** (`test_connection` signature alignment across bluesky/discord/mastodon/matrix/microblog/webhook): re-scoped out during implementation. Aligning these 6 functions onto one `test_connection(account: dict)` shape would touch 6 production modules' public signatures plus 12 call sites (6 in `app.py`, 6 in tests) for a purely architectural/typing benefit — no bug fix, no duplication reduction. The duplication audit's own adoption record already rejected the closely-related §2.7 finding (merging these same 6 functions' *internal* try/except skeleton) with the same reasoning: "the mechanical savings don't justify" the churn. Applying that same bar here, the signature-alignment version of the idea doesn't clear it either. Left as a documented, deliberately-skipped recommendation rather than silently dropped.
+
+**Not attempted in this PR (out of scope, large L-effort structural work):**
+- **§4.1** (Repository pattern) and **§4.2** (Service layer): confirmed still absent (243 raw `db.execute()` calls in `app.py` as of this snapshot; not re-counted post-adoption since neither this nor the duplication-audit adoption touched that surface). These remain the correct next large project — see §4.1's own text for why they should be sequenced after `[CX §5.1]`'s route-module split, not attempted as one big-bang change.
+- **§9** (DB connection pooling): not in this PR's scope; unchanged from the audit's original recommendation.
+
+**Verification:** full test suite (`pytest`, SQLite) run before any change (1497 passed, 36 skipped) and after all five landed changes (1497 passed, 36 skipped, identical) — no regressions. Targeted destination-module, scheduler, reader/saved-search, and auth test files were also run individually after each change before the final full-suite pass. Postgres-dialect tests were not run locally (no local Postgres instance); none of the five changes touch dialect-specific code paths (`database.py`'s SQLite/Postgres branches were not modified).

--- a/matrix.py
+++ b/matrix.py
@@ -43,6 +43,8 @@ import httpx
 from feed_parser import SSRFError, pinned_request, validate_outbound_url
 from utils import (
     DEFAULT_REQUEST_TIMEOUT,
+    DestinationAuthError,
+    DestinationError,
     json_error_detail,
     truncate_chars,
 )
@@ -71,16 +73,21 @@ _ROOM_ALIAS_RE = re.compile(r"^#[^\s:]+:[^\s:/]+(:\d+)?$")
 _URL_RE = re.compile(r"https?://[^\s<>\"]+")
 
 
-class MatrixError(Exception):
+class MatrixError(DestinationError):
     """Base error for Matrix API interactions."""
 
 
-class MatrixAuthError(MatrixError):
+class MatrixAuthError(MatrixError, DestinationAuthError):
     """Access token rejected, expired, or revoked (M_UNKNOWN_TOKEN)."""
 
 
-class MatrixPermissionError(MatrixError):
-    """Token is valid but cannot post here (not joined, no power level)."""
+class MatrixPermissionError(MatrixError, DestinationAuthError):
+    """Token is valid but cannot post here (not joined, no power level).
+
+    Shares DestinationAuthError with MatrixAuthError: both are permanent,
+    not-worth-retrying failures until the user acts on the Matrix side —
+    scheduler.py already treats them identically (permanent=True).
+    """
 
 
 def _error_detail(response) -> str:

--- a/microblog.py
+++ b/microblog.py
@@ -20,7 +20,7 @@ import logging
 import httpx
 
 from feed_parser import SSRFError, pinned_request
-from utils import DEFAULT_REQUEST_TIMEOUT, json_error_detail
+from utils import DEFAULT_REQUEST_TIMEOUT, DestinationAuthError, DestinationError, json_error_detail
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +29,11 @@ REQUEST_TIMEOUT = DEFAULT_REQUEST_TIMEOUT
 TOKEN_DISPLAY_MAX = 8
 
 
-class MicroblogError(Exception):
+class MicroblogError(DestinationError):
     """Base error for Micro.blog API interactions."""
 
 
-class MicroblogAuthError(MicroblogError):
+class MicroblogAuthError(MicroblogError, DestinationAuthError):
     """Token rejected, expired, or revoked."""
 
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -6,6 +6,7 @@ import json
 import logging
 import secrets
 import threading
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -84,6 +85,7 @@ from notify import (
 )
 from template_engine import render_template
 import alt_text
+from utils import FeedItem
 from utils import utc_now_str as _now
 
 logger = logging.getLogger("feedecho.scheduler")
@@ -585,7 +587,7 @@ def db_feed_url(feed_id: int) -> str:
     return row["url"]
 
 
-def _claim_post(echo_id: int, item: dict) -> tuple[int, str] | None:
+def _claim_post(echo_id: int, item: FeedItem) -> tuple[int, str] | None:
     """Atomically claim an echo/item row.
 
     Returns ``(posted_item_id, claim_token)`` only for the worker that owns the
@@ -681,7 +683,7 @@ def _post_succeeded(echo_id: int, item_id: str) -> bool:
     return _row_state(echo_id, item_id) in ("success", "filtered", "gave_up", "queued")
 
 
-def _record_filtered(echo_id: int, item: dict, reason: str | None = None) -> None:
+def _record_filtered(echo_id: int, item: FeedItem, reason: str | None = None) -> None:
     """Record an item suppressed by the echo's keyword filter.
 
     Uses status 'filtered' so history shows what was dropped and the claim
@@ -706,7 +708,7 @@ def _record_filtered(echo_id: int, item: dict, reason: str | None = None) -> Non
 
 def process_echo(
     echo,
-    item: dict,
+    item: FeedItem,
     feed_name: str = "",
     override_content: str | None = None,
 ) -> bool:
@@ -815,7 +817,7 @@ def _drip_rate(echo_id: int) -> int:
     return row["n"] if row else 0
 
 
-def _queue_for_drip(echo, item: dict, posted_id: int, claim_token: str) -> bool:
+def _queue_for_drip(echo, item: FeedItem, posted_id: int, claim_token: str) -> bool:
     """Hold an item until the drip window has room.
 
     Marks the posted row 'queued' (terminal for the cursor, same as
@@ -905,7 +907,7 @@ def _reclaim_queued(echo_id: int, item_id: str) -> tuple[int, str] | None:
 
 def _render_and_dispatch(
     echo,
-    item: dict,
+    item: FeedItem,
     feed_name: str,
     posted_id: int,
     claim_token: str,
@@ -949,69 +951,13 @@ def _render_and_dispatch(
         gave_up = _fail_post(posted_id, claim_token, echo_id, "Rendered content was empty")
         return gave_up
 
-    if echo["destination_type"] == "mastodon":
-        return _send_mastodon(echo, item, content, echo["destination_id"], posted_id, claim_token)
+    destination_type = echo["destination_type"]
+    if destination_type == "webhook":
+        return _send_webhook(echo, item, content, feed_name, echo["destination_id"], posted_id, claim_token)
 
-    if echo["destination_type"] == "email":
-        return _send_email_echo(
-            echo,
-            item,
-            content,
-            echo["destination_id"],
-            posted_id,
-            claim_token,
-        )
-
-    if echo["destination_type"] == "bluesky":
-        return _send_bluesky(
-            echo,
-            item,
-            content,
-            echo["destination_id"],
-            posted_id,
-            claim_token,
-        )
-
-    if echo["destination_type"] == "microblog":
-        return _send_microblog(
-            echo,
-            item,
-            content,
-            echo["destination_id"],
-            posted_id,
-            claim_token,
-        )
-
-    if echo["destination_type"] == "matrix":
-        return _send_matrix(
-            echo,
-            item,
-            content,
-            echo["destination_id"],
-            posted_id,
-            claim_token,
-        )
-
-    if echo["destination_type"] == "discord":
-        return _send_discord(
-            echo,
-            item,
-            content,
-            echo["destination_id"],
-            posted_id,
-            claim_token,
-        )
-
-    if echo["destination_type"] == "webhook":
-        return _send_webhook(
-            echo,
-            item,
-            content,
-            feed_name,
-            echo["destination_id"],
-            posted_id,
-            claim_token,
-        )
+    handler = _DESTINATION_HANDLERS.get(destination_type)
+    if handler is not None:
+        return handler(echo, item, content, echo["destination_id"], posted_id, claim_token)
 
     gave_up = _fail_post(
         posted_id,
@@ -1129,7 +1075,7 @@ def _fail_post(
     return final == "gave_up"
 
 
-def _item_image_entries(item: dict, limit: int = 4) -> list[dict]:
+def _item_image_entries(item: FeedItem, limit: int = 4) -> list[dict]:
     """Image URL/alt entries from an item, shared by destination senders.
 
     Returns up to `limit` entries of {"url", "alt"} taken from the item's
@@ -1280,7 +1226,7 @@ def _finalize_success(
 
 def _send_mastodon(
     echo,
-    item: dict,
+    item: FeedItem,
     content: str,
     account_id: int,
     posted_id: int,
@@ -1384,7 +1330,7 @@ def _send_mastodon(
 
 def _send_email_echo(
     echo,
-    item: dict,
+    item: FeedItem,
     content: str,
     email_account_id: int,
     posted_id: int,
@@ -1534,7 +1480,7 @@ def _bsky_session(account) -> dict:
 
 def _send_bluesky(
     echo,
-    item: dict,
+    item: FeedItem,
     content: str,
     account_id: int,
     posted_id: int,
@@ -1716,7 +1662,7 @@ def _send_bluesky(
 
 def _send_microblog(
     echo,
-    item: dict,
+    item: FeedItem,
     content: str,
     account_id: int,
     posted_id: int,
@@ -1819,7 +1765,7 @@ def _send_microblog(
 
 def _send_matrix(
     echo,
-    item: dict,
+    item: FeedItem,
     content: str,
     account_id: int,
     posted_id: int,
@@ -1994,7 +1940,7 @@ def _matrix_image_filename(content_type: str) -> str:
 
 def _send_discord(
     echo,
-    item: dict,
+    item: FeedItem,
     content: str,
     account_id: int,
     posted_id: int,
@@ -2067,7 +2013,7 @@ def _send_discord(
 
 def _send_webhook(
     echo,
-    item: dict,
+    item: FeedItem,
     content: str,
     feed_name: str,
     account_id: int,
@@ -2126,9 +2072,29 @@ def _send_webhook(
     return _finalize_success(posted_id, claim_token, echo["id"], post_url="")
 
 
+# Strategy registry: destination_type -> sender. All seven share the
+# (echo, item, content, account_id, posted_id, claim_token) -> bool shape
+# except _send_webhook, which additionally needs feed_name for its payload
+# template — handled as a special case in _render_and_dispatch rather than
+# forcing an unused parameter onto the other six. Replaces a 7-arm
+# if/elif chain that was hand-copied in at least four other places
+# (add_echo/edit_echo's destination-field resolution, echoes.html's
+# destination-type badge, and the two account-table registries in app.py
+# and import_export.py) — this is the one place a destination TYPE maps to
+# posting BEHAVIOR, as opposed to a table name or form field.
+_DESTINATION_HANDLERS: dict[str, Callable[[dict, FeedItem, str, int, int, str], bool]] = {
+    "mastodon": _send_mastodon,
+    "email": _send_email_echo,
+    "bluesky": _send_bluesky,
+    "microblog": _send_microblog,
+    "matrix": _send_matrix,
+    "discord": _send_discord,
+}
+
+
 def _queue_for_digest(
     echo,
-    item: dict,
+    item: FeedItem,
     content: str,
     posted_id: int,
     claim_token: str,

--- a/utils.py
+++ b/utils.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import re
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from typing import TypedDict
 
 # Default HTTP request timeout (seconds) shared by the destination
 # modules. Replaces the four independent REQUEST_TIMEOUT = 30 constants.
@@ -137,3 +138,64 @@ def rows_to_dict(rows) -> dict:
     email_sender.get_system_smtp_settings, and alt_text._get_settings.
     """
     return {row["key"]: row["value"] for row in rows}
+
+
+# Shared exception ancestors for the five destination adapters (bluesky,
+# discord, matrix, microblog, webhook — mastodon has no custom exceptions
+# today). Each module's own <Platform>Error keeps subclassing Exception
+# via this shared base instead, and its Auth/NotFound/RateLimit subclasses
+# additionally inherit the matching Destination*Error below via multiple
+# inheritance — every existing `except BlueskyAuthError` (etc.) call site
+# is unaffected, since the module-specific class still exists with the
+# same name and MRO position. This only adds a shared ancestor so code
+# that wants to (e.g. a future generic exception ladder in scheduler.py)
+# can catch "any destination's auth failure" without importing all five
+# modules' independent hierarchies. Design-patterns audit finding 2.3.
+class DestinationError(Exception):
+    """Base for every destination-adapter failure."""
+
+
+class DestinationAuthError(DestinationError):
+    """Rejected credentials or insufficient permission — permanent, not worth retrying."""
+
+
+class DestinationNotFoundError(DestinationError):
+    """The target (channel/room/blog/webhook/instance) no longer exists."""
+
+
+class DestinationRateLimitError(DestinationError):
+    """Caller should back off. Subclasses set retry_after (seconds) themselves."""
+
+    retry_after: float | None = None
+
+
+class FeedItem(TypedDict, total=False):
+    """The template-facing shape of one feed item, as consumed by
+    render_template() and every _send_X destination function in
+    scheduler.py.
+
+    Documentation, not an enforced contract: total=False because a
+    backdated/drip-redelivered item reconstructed from the feed_items
+    table may carry a subset of these keys, and because feed_parser.py's
+    parse_rss_feed/parse_json_feed (the source of a freshly-fetched item)
+    is the only place all of them are populated at once. Design-patterns
+    audit finding 4.3 — added at the scheduler.py dispatch boundary as a
+    zero-runtime-cost type hint; no call site's actual dict construction
+    changes.
+    """
+
+    id: str
+    title: str
+    link: str
+    summary: str
+    content: str
+    content_text: str
+    content_link: str
+    author: str
+    date: str
+    tags: list[str]
+    image_url: str
+    image_alt: str
+    image_urls: list[dict]
+    enclosure_url: str
+    raw: dict

--- a/webhook.py
+++ b/webhook.py
@@ -46,7 +46,14 @@ import httpx
 
 import settings
 from feed_parser import SSRFError, ssrf_client, unpinned_client, validate_outbound_url
-from utils import DEFAULT_REQUEST_TIMEOUT, parse_retry_after
+from utils import (
+    DEFAULT_REQUEST_TIMEOUT,
+    DestinationAuthError,
+    DestinationError,
+    DestinationNotFoundError,
+    DestinationRateLimitError,
+    parse_retry_after,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,11 +67,11 @@ MAX_HEADER_COUNT = 20
 MAX_HEADERS_TEXT = 4000
 
 
-class WebhookError(Exception):
+class WebhookError(DestinationError):
     """Base error for webhook delivery."""
 
 
-class WebhookRateLimitError(WebhookError):
+class WebhookRateLimitError(WebhookError, DestinationRateLimitError):
     """429 rate limit. Transient; carries the server's suggested wait."""
 
     def __init__(self, retry_after: float | None = None):
@@ -75,11 +82,11 @@ class WebhookRateLimitError(WebhookError):
         super().__init__(msg)
 
 
-class WebhookAuthError(WebhookError):
+class WebhookAuthError(WebhookError, DestinationAuthError):
     """401/403 — the endpoint rejected our credentials."""
 
 
-class WebhookNotFoundError(WebhookError):
+class WebhookNotFoundError(WebhookError, DestinationNotFoundError):
     """404/410 — the endpoint no longer exists."""
 
 


### PR DESCRIPTION
## Summary

Implements the well-scoped findings from the 2026-09-08 design-patterns audit (`docs/reviews/2026-09-08-design-patterns-audit.md`, filed in this PR). Scope was deliberately narrowed during implementation — see "Not in this PR" below.

- **Finding 1.3** — `scheduler.py`'s `_render_and_dispatch` dispatched to the 7 destination senders via a 62-line if/elif chain. Replaced with a `_DESTINATION_HANDLERS` dict (Strategy/Factory registry); `webhook` stays a special case ahead of the lookup since it alone needs an extra `feed_name` arg. Zero behavior change.
- **Finding 2.3** — bluesky/discord/matrix/microblog/webhook each had an independent exception hierarchy with no shared ancestor, so "catch any destination's auth failure" wasn't possible without importing all five. Added `DestinationError`/`DestinationAuthError`/`DestinationNotFoundError`/`DestinationRateLimitError` to `utils.py`; each module's own error classes now additionally inherit the matching shared base via multiple inheritance. Every existing `except BlueskyAuthError`-style call site is unaffected — verified all resulting MROs resolve cleanly and existing custom `__init__` behavior (e.g. `retry_after` attributes) is untouched.
- **Finding 4.3** — added `utils.FeedItem` (`TypedDict, total=False`, built from `feed_parser.py`'s actual item-dict keys) and applied it to every `item: dict` parameter in `scheduler.py`'s dispatch path (14 sites). Pure type-hint addition, no runtime behavior change.
- **Finding 2.8** — `_saved_search_counts_cache` was a bare module-level dict invalidated via `.pop(uid, None)` copy-pasted at 9 call sites. Wrapped in `_SavedSearchCountsCache` with `.get()`/`.set()`/`.invalidate()`, same invalidation semantics.
- **Finding 3.2** — `auth.login_submit` branched on `settings.MULTI` for its entire body, running two unrelated auth algorithms in one function. Split into `_login_single_mode`/`_login_multi_mode` behind a 2-line dispatcher; public signature unchanged.

## Context: what changed upstream since the audit was written

Between writing the audit and implementing it, master moved ~30 commits on an independent adoption of the companion duplication audit (`docs/reviews/2026-09-08-code-duplication-audit.md`). That work already extracted `scheduler.py`'s shared per-item helpers (`_destination_account`, `_echo_attach_image`, etc.) — re-verified before starting that it had **not** touched the dispatch if/elif chain or added exception base classes, so findings 1.3 and 2.3 above were still live and correctly scoped against current code, not the audit's original snapshot.

## Not in this PR

- **Finding 2.2** (`test_connection` signature alignment across the 6 destination modules) — reconsidered during implementation and dropped. It would touch 6 production signatures and 12 call sites for a purely architectural benefit with no bug fix or duplication reduction. The duplication audit's own adoption record already rejected a closely-related consolidation (its §2.7) on exactly this "not worth the churn" reasoning; applying the same bar here gave the same answer. Documented as a deliberate skip in the audit's adoption-outcome section, not silently dropped.
- **Findings 4.1/4.2** (Repository pattern / Service layer) — confirmed still absent (243 raw `db.execute()` calls in `app.py`), but this is large, L-effort structural work that should be its own project, sequenced after the complexity audit's recommended route-module split — not attempted as one big-bang change here.
- The code-complexity audit (`docs/reviews/2026-09-08-code-complexity-audit.md`) is filed in this PR as a reference document; none of its findings were actioned here.

## Test plan

- [x] Full test suite run before any change: 1497 passed, 36 skipped (baseline).
- [x] Full test suite run after all five changes: 1497 passed, 36 skipped — identical, no regressions.
- [x] Targeted runs after each individual change (destination/scheduler tests after findings 1.3/2.3/4.3, reader/saved-search tests after 2.8, auth tests after 3.2).
- [x] Verified exception MRO resolution and preserved instance attributes (e.g. `DiscordRateLimitError.retry_after`) directly in a Python shell.
- [ ] Postgres-dialect tests not run locally (no local Postgres instance) — none of these changes touch `database.py`'s dialect branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ