### PR TITLE
UX audit fixes: mobile nav discoverability, Echoes empty state, and primary-color review

### DIFF
--- a/docs/reviews/2026-09-08-ux-interface-audit.md
+++ b/docs/reviews/2026-09-08-ux-interface-audit.md
@@ -1,0 +1,76 @@
+# FeedEcho — UX Interface & Navigation Audit
+
+**Date:** 2026-09-08
+**Scope:** Live interaction review of the running multi-mode app (registration, dashboard, Feeds, Accounts, Echoes, Reader, mobile viewport) at commit `8a3a5ed` (v1.51.1), using a real browser session (Chrome via automated interaction), not just template/CSS reading.
+**Method:** Launched the app locally (`FEEDECHO_MODE=multi`, SQLite fallback), registered a fresh account, and walked the primary flows a new user would hit first: landing → sign up → dashboard → Feeds → Accounts → Echoes → Reader, plus a resize to a 390px mobile viewport. Every finding below was confirmed with either a screenshot, a DOM/computed-style check (`getComputedStyle`, element geometry), or a source read — not assumed from templates alone. See [§ Adoption outcome](#adoption-outcome-2026-09-08-post-audit) for what was implemented.
+
+---
+
+## Findings, prioritized by impact
+
+### 1. The brand's "primary" color reads as an error/danger signal — everywhere, starting at signup (Importance: 9/10)
+
+**Problem:** `--primary` derives from `--hue-coral: 35` (`static/css/style.css`), used for the Sign Up button, every input's focus ring, the active nav-tab underline, the trial-status banner border, and the dashboard's "Accounts" stat number. `--danger` sits at hue 25 — only 10° away in the same warm red-orange band, not reliably distinguishable on a neutral background, especially for red-green color vision deficiency.
+
+Confirmed directly: on `/register`, the autofocused (empty) email field showed a thick coral ring and the submit button rendered dark coral — before any interaction. Verified via `getComputedStyle` that this was the deliberate `--primary` focus/button color (not a native `:invalid` state — the ring persisted after typing a syntactically valid email, `validity.valid: true`). Verified via the dashboard that "Accounts: 0" renders in the same coral (`oklch(0.46 0.19 35)`) while "Feeds: 0" — an equally benign zero — renders in calm teal (`oklch(0.47 0.12 195)`), with no apparent logic for the difference. The trial-status banner's border is the same coral (`.trial-banner { border: 1px solid oklch(0.46 0.19 35) }`), giving a routine "13 days left" notice the same visual weight as an actual warning.
+
+**Why it matters:** A brand-new user's very first interaction with the product (signup) visually reads as "something's wrong," and the same signal recurs at nearly every important, benign moment afterward (account status, active nav tab, a zero-state stat).
+
+### 2. On mobile, three of nine nav destinations were invisible with no hint they existed (Importance: 8/10)
+
+**Problem:** Below 640px, `.nav-links` scrolled horizontally with the scrollbar hidden (`scrollbar-width: none`). At a 390px viewport, "Dashboard Feeds Reader Queue Accounts Echoes" exactly filled the visible strip; History, Settings, and How To were pushed off-screen (measured "History" rendering at x=494 in a 500px-wide viewport) with zero edge fade, arrow, or partial-item peek indicating more tabs existed. Confirmed reachable only by an undiscoverable swipe (scripted `scrollLeft` revealed them).
+
+**Why it matters:** Three entire sections — including Settings, where SMTP/API keys/plan info live — had no visible path to them on mobile, while the nav visually looked "complete."
+
+### 3. The Echoes page showed blank, unlabeled dropdowns with no guidance when prerequisites weren't met (Importance: 7/10)
+
+**Problem:** `/echoes` requires a feed and a connected destination first, but if neither existed, the "Feed" and "Destination" `<select>` elements rendered with zero `<option>` tags (confirmed via DOM query: `options: []`) — a blank box, no placeholder. Feeds and Accounts pages both handle their own empty state with a clear message ("No feeds yet. Add one above to get started." / "No accounts yet. Connect a Mastodon instance..."); Echoes — the "put it all together" step in the product's own onboarding pitch — didn't.
+
+### 4. A working "manual connect" option was invisible — styled as plain text (Importance: 6/10)
+
+**Problem:** On Accounts → Mastodon, "Or add Mastodon manually with a token" is a functional `<details>/<summary>` toggle (confirmed by clicking it — it expanded a full second form), but rendered with no color, no underline, no marker — `color: var(--text-muted)` and no chevron. Only `cursor: pointer` hinted it was interactive, which isn't visible in a static view.
+
+### 5. One dropdown rendered as a raw, unstyled native `<select>` (Importance: 5/10)
+
+**Problem:** The Feeds page's "Folder" dropdown (`<select name="folder_id" id="feed-folder">` in `templates/feeds.html`, no CSS class) fell back to the OS-native control appearance — a solid dark pill next to light, custom-styled text inputs — because `.inline-form` (the form's class) styled `input`/`button` but not `select` (`static/css/style.css:426`, confirmed by grep). Every select checked elsewhere in the app (Echoes' Feed/Destination pickers) was correctly styled — an isolated gap in one form, not a systemic issue.
+
+### 6. Placeholder text meant to show the URL format was cut off (Importance: 4/10)
+
+**Problem:** The feed URL field's placeholder (`https://example.com/feed.xml`) showed only `https://example.com/fee` — confirmed at both 390px and 1400px widths, so it's the field's fixed proportion within the row (`.inline-form input { flex: 1 }`, giving Name/URL/Poll-interval equal width regardless of content length), not a small-screen artifact.
+
+### 7. Native browser validation errors don't match the app's design language (Importance: 3/10 — noted, not fixed)
+
+**Problem:** Submitting an invalid feed URL triggers Chrome's built-in validation bubble ("Please enter a URL.") — OS-styled, generic copy, dropped into an otherwise fully custom UI.
+
+### 8. Two adjacent toggle-button groups on the Reader page used different "selected" visual languages (Importance: 3/10)
+
+**Problem:** The view-filter tabs (Unread/All/Starred/Today) showed the active one with a solid coral fill (`.reader-tab.active { background: var(--primary) }`); the display-option toggles right below (Compact/Auto-read/Full text) showed "on" as a wash-tint outline instead (`.btn-sm[aria-pressed="true"] { background: var(--primary-wash); border-color: var(--primary) }`) — same row, same concept, two conventions.
+
+### Positive: the Reader's keyboard-shortcuts modal is genuinely well designed
+
+The `?` button opens a clean, well-organized shortcuts + search-operator reference (`j`/`k` navigation, `is:starred`, `feed:name`, etc.) — exactly the kind of feature a design-literate, power-user audience appreciates. Its only weakness is discoverability: reachable only via a small, unlabeled `?` button with no other hint (onboarding, empty states) that it exists. Not changed in this PR — a "Press `?` for shortcuts" hint somewhere on first Reader visit would be a reasonable low-cost follow-up, but is a content/onboarding decision more than a bug fix.
+
+---
+
+## Adoption outcome (2026-09-08, post-audit)
+
+**Landed (this PR):**
+- **§2** (mobile nav discoverability): added `.nav-links-wrap`, a non-scrolling wrapper around `.nav-links` that positions a fixed-edge fade (`::after` gradient into `var(--surface)`) at the visible right edge of the tab strip — stays put regardless of the inner strip's scroll offset, giving a permanent "more content" cue. `.nav-links-wrap { display: contents }` by default so desktop's `.nav-links { margin-left: auto }` still works as a direct flex child of `.navbar`; the mobile media query gives the wrapper its own box (`order: 4`, `flex: 1 1 100%`, `position: relative`) and moves `margin-left: 0` onto `.nav-links` itself. Cache-buster bumped `style.css?v=56` → `?v=57` (and every test asserting that literal string updated to match, per the project's existing convention of pinning it). This is a static fade (doesn't disappear once scrolled to the end) — a scroll-position-aware version is a reasonable follow-up, noted in the CSS comment.
+- **§3** (Echoes empty-state guidance): `templates/echoes.html` now computes `has_destination` from the seven per-platform account lists already passed into the template (no route/Python change needed) and, when `not feeds or not has_destination`, replaces the create-echo form with a message naming exactly what's missing ("at least one feed and one connected destination" / "at least one feed" / "a connected destination") plus links to `/feeds` and/or `/accounts`. Also fixed a redundant-message bug this introduced: the pre-existing "No echoes yet. Create one above." empty state (for when the form IS showing but no echoes exist yet) is now gated on `feeds and has_destination` too, so it no longer says "above" when the form isn't there.
+- **§4** (manual-connect affordance): `.manual-section summary` now gets a chevron (`::after { content: "▾" }`, rotated when closed, matching the pattern already used one level up for the account-type accordions themselves), an underline on hover, and a visible focus ring — same treatment as every other disclosure control in the app, applied for consistency rather than invented fresh.
+- **§5** (unstyled select): added `select` to the `.inline-form` input/button/focus selector list (`static/css/style.css:426`) — the `form-row` equivalent rule already included `select` (confirmed by reading the existing focus-visibility test), so this brings `.inline-form` in line with the project's own established convention rather than introducing a new one.
+- **§6** (truncated placeholder): `#feed-url { flex: 2.5 }` gives the URL field a larger share of the row than poll-interval/folder need, instead of every field getting an equal `flex: 1`.
+- **§8** (Reader toggle consistency): `.reader-toolbar-right .btn-sm[aria-pressed="true"]` now uses solid `var(--primary)` fill + `var(--primary-contrast)` text (matching `.reader-tab.active`) instead of the wash-tint outline.
+- **§1** (color hue), **partially, flagged for review**: shifted `--hue-coral` from `35` to `50` — roughly midway between `--hue-red` (25) and `--hue-gold` (85), so it no longer sits adjacent to either. This is a **brand-color judgment call, not a bug fix** — implemented as a single, isolated, easily-tunable CSS custom property (one line) specifically so it's simple to adjust or revert if a different hue is wanted; not treated as a settled decision. **Please review this one specifically.**
+
+**Not implemented:**
+- **§7** (native validation styling): left as-is. Replacing browser-native validation UI risks an accessibility regression (screen readers handle native `:invalid`/validation messages well; a custom replacement needs its own `aria-live` and focus-management work to not be a net loss) that's a bigger, more careful effort than this PR's other fixes warrant. Noted as a real but lower-priority (3/10) finding for a future, dedicated pass.
+- Reader shortcuts discoverability (mentioned under the positive finding above): a content/onboarding decision, not a bug — left for product judgment.
+
+**Verification:**
+- Full test suite: 1502 passed / 36 skipped before any change; 1503 passed / 36 skipped after (one new test added: `test_nav_links_wrap_has_scroll_edge_fade`).
+- Four pre-existing tests initially broke from the mobile-nav restructuring and the `.inline-form` selector change (`test_mobile_nav.py`'s order/overflow assertions, `test_ux_p1_fixes.py`'s focus-rule text match, and four separate cache-buster version-string assertions across `test_admin_mobile_actions.py`/`test_mobile_form_layout.py`/`test_trial_limits_visibility.py`/`test_ux_p2_fixes.py`) — all updated to match the new, deliberate structure rather than reverting the fix to avoid touching tests.
+- CSS verified brace-balanced (no syntax errors) after all edits.
+- All nine primary routes (`/`, `/feeds`, `/accounts`, `/echoes`, `/reader`, `/settings`, `/history`, `/queue`, `/howto`) verified to return 200 with no server-error markers in the response body, via a scripted register → browse session against a live local instance.
+- The Echoes empty-state logic specifically verified across two states (no feed + no destination; feed added, no destination) by adding a real feed via the API and re-checking the rendered message text and links updated correctly.
+- **Not re-verified visually**: the Chrome browser session used for the initial audit disconnected mid-session and did not reconnect, so the CSS/template fixes above were validated functionally (tests, curl, computed-style checks earlier in the audit) but not re-screenshotted after implementation. Flagging this explicitly rather than claiming a visual check that didn't happen — worth a manual look before merging, particularly the color-hue change (§1) and the nav scroll-fade (§2), since both are visual-only effects that don't fail a functional test if wrong.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -145,6 +145,11 @@ body {
   vertical-align: -5px; /* optically center the tile against the nav text */
   margin-right: 0.15rem;
 }
+/* display:contents by default so this wrapper (added only to give the
+   mobile scroll-fade below a non-scrolling positioning context) doesn't
+   become a flex item itself on desktop — .nav-links's margin-left:auto
+   needs to act as a direct child of .navbar to push the tab strip right. */
+.nav-links-wrap { display: contents; }
 .nav-links {
     display: flex;
     gap: 0.15rem;
@@ -423,7 +428,7 @@ h2 { font-size: 1.1rem; margin: 1.25rem 0 0.5rem; }
     flex-wrap: wrap;
     margin-bottom: 0.75rem;
 }
-.inline-form input, .inline-form button {
+.inline-form input, .inline-form select, .inline-form button {
     padding: 0.5rem 0.75rem;
     border: 1px solid var(--border);
     border-radius: 6px;
@@ -432,12 +437,18 @@ h2 { font-size: 1.1rem; margin: 1.25rem 0 0.5rem; }
     font-size: 0.9rem;
     min-height: 44px; /* iOS touch target */
 }
-.inline-form input { flex: 1; min-width: 0; }
-.inline-form input:focus {
+.inline-form input, .inline-form select { flex: 1; min-width: 0; }
+.inline-form input:focus, .inline-form select:focus {
     border-color: var(--primary);
     outline: 2px solid var(--primary);
     outline-offset: 1px;
 }
+/* The URL field's placeholder ("https://example.com/feed.xml") is the
+   longest and most informative of the row's placeholders — give it more
+   of the row's width than poll-interval/folder need, instead of every
+   field getting an equal flex:1 share and truncating it. UX audit
+   finding 6 (2026-09-08). */
+#feed-url { flex: 2.5; }
 
 /* Accounts "add account" forms stack each field on its own line at every
    viewport width. .inline-form is row-flex by default, so a multi-field
@@ -578,9 +589,19 @@ h2 { font-size: 1.1rem; margin: 1.25rem 0 0.5rem; }
     .nav-brand   { order: 1; flex: 0 1 auto; min-width: 0; }
     .theme-toggle { order: 2; flex: 0 0 auto; margin-left: auto; min-height: 44px; min-width: 44px; }
     .nav-account  { order: 3; flex: 0 0 auto; margin-left: 0; padding-left: 0; border-left: 0; position: relative; }
-    .nav-links {
+    /* Wraps .nav-links so the "more content" fade below can stay fixed at
+       the visible edge — a fade generated on .nav-links itself would be
+       inside the scrolling content and scroll away with it instead of
+       overlaying the viewport edge. */
+    .nav-links-wrap {
+        display: block;
+        position: relative;
         order: 4;
         flex: 1 1 100%;
+        margin-left: 0;
+        min-width: 0;
+    }
+    .nav-links {
         margin-left: 0;
         flex-wrap: nowrap;
         overflow-x: auto;
@@ -590,6 +611,24 @@ h2 { font-size: 1.1rem; margin: 1.25rem 0 0.5rem; }
         -webkit-overflow-scrolling: touch;
     }
     .nav-links::-webkit-scrollbar { display: none; }
+    /* With the scrollbar hidden, a fully-filled first screen (e.g. exactly
+       6 tabs fitting the viewport) gave zero visual indication that
+       History/Settings/How To existed further right — reachable only by
+       an undiscoverable swipe. This fade is a static "more content" cue
+       (it doesn't disappear once scrolled to the end — a scroll-position
+       -aware version is a reasonable follow-up, but this alone fixes the
+       "looks complete when it isn't" problem). UX audit finding 2
+       (2026-09-08). */
+    .nav-links-wrap::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 28px;
+        pointer-events: none;
+        background: linear-gradient(to right, transparent, var(--surface));
+    }
     .nav-links a {
         flex: 0 0 auto;
         min-height: 44px;              /* touch target */
@@ -960,6 +999,26 @@ code {
     min-height: 44px;
     display: flex;
     align-items: center;
+    gap: 0.4rem;
+    list-style: none;
+    user-select: none;
+}
+/* This <details> toggle previously had no visual cue distinguishing it
+   from plain body text (cursor:pointer alone isn't visible in a static
+   screenshot or discoverable without hovering) — matches the chevron
+   pattern already used for details.account-section below. UX audit
+   finding 4 (2026-09-08). */
+.manual-section summary::-webkit-details-marker { display: none; }
+.manual-section summary::after {
+    content: "▾";
+    color: var(--text-muted);
+    transition: transform 0.15s ease;
+}
+.manual-section details:not([open]) > summary::after { transform: rotate(-90deg); }
+.manual-section summary:hover { color: var(--text); text-decoration: underline; }
+.manual-section summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
 }
 
 /* Responsive heading sizes */
@@ -1557,8 +1616,18 @@ details.account-section > summary:focus-visible {
 .reader-feed-avatar { display: inline-flex; align-items: center; justify-content: center; width: 1.4rem; height: 1.4rem; border-radius: 50%; background: var(--primary-wash); color: var(--primary); font-size: 0.7rem; font-weight: 700; flex-shrink: 0; }
 .reader-feed-error { color: #d97706; flex-shrink: 0; }
 
-/* Tier 2 — toggle buttons show their pressed state */
-.reader-toolbar-right .btn-sm[aria-pressed="true"] { background: var(--primary-wash); border-color: var(--primary); color: var(--primary); }
+/* Tier 2 — toggle buttons show their pressed state.
+   Solid fill instead of the previous wash-tint-only treatment, to match
+   .reader-tab.active's "selected" language above — the two adjacent
+   toggle groups (Unread/All/Starred/Today vs. Compact/Auto-read/Full
+   text) previously used different visual conventions for the same
+   "currently on" state. UX audit finding 8 (2026-09-08). */
+.reader-toolbar-right .btn-sm[aria-pressed="true"] {
+    background: var(--primary);
+    border-color: var(--primary);
+    color: var(--primary-contrast);
+    font-weight: 600;
+}
 
 /* Compact density: title only, no feed/author/date meta line */
 .reader[data-density="compact"] .reader-item-meta { display: none; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,7 +2,19 @@
 
 :root {
     /* Shared brand hues (OKLCH: lightness chroma hue) */
-    --hue-coral: 35;    /* warm coral — primary */
+    /* UX audit finding 1 (2026-09-08): this was 35, only 10° from
+       --hue-red (25) below — on a neutral background that's not reliably
+       distinguishable from the danger color, especially for anyone with
+       a red-green color vision deficiency, and it showed up concretely
+       on first load (the Sign Up button + the autofocused, empty email
+       field's focus ring both read as an error state before any
+       interaction). 50 keeps the same warm, energetic family the
+       "coral" name and comment describe while sitting roughly midway
+       between --hue-red (25) and --hue-gold (85), so it no longer
+       collides with either. This is a brand-color judgment call, not a
+       bug fix — flagged in the PR for design review; the number is a
+       single, easily-tunable value if a different target hue is wanted. */
+    --hue-coral: 50;
     --hue-teal: 195;    /* teal — secondary/info */
     --hue-gold: 85;     /* golden — warning */
     --hue-green: 150;   /* success */

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f6f8">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/css/style.css?v=56">
+    <link rel="stylesheet" href="/static/css/style.css?v=57">
     <link rel="apple-touch-icon" href="/favicon.svg">
     <script>
     // Set theme before first paint to avoid flash. Three states stored in
@@ -37,6 +37,7 @@
         <a href="/" class="nav-brand">
             <img src="/static/img/logo.svg" alt="" aria-hidden="true" class="nav-icon" width="22" height="22"> FeedEcho
         </a>
+        <div class="nav-links-wrap">
         <div class="nav-links">
             {% if authed %}
             <a href="/" {% if request.url.path == '/' %}aria-current="page" class="active"{% endif %}>Dashboard</a>
@@ -56,6 +57,7 @@
             <a href="/login" {% if request.url.path == '/login' %}aria-current="page" class="active"{% endif %}>Log in</a>
             <a href="/register" {% if request.url.path == '/register' %}aria-current="page" class="active"{% endif %}>Sign up</a>
             {% endif %}
+        </div>
         </div>
         <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch theme" title="Switch theme">◐</button>
         <span class="sr-only" id="theme-mode-live" aria-live="polite"></span>

--- a/templates/echoes.html
+++ b/templates/echoes.html
@@ -5,6 +5,17 @@
 
 <p class="hint">An Echo routes items from a Feed to a destination (Mastodon, Bluesky, micro.blog, Matrix, Discord, a generic webhook, or email) using a template.</p>
 
+{% set has_destination = mastodon_accounts or email_accounts or bluesky_accounts or microblog_accounts or matrix_accounts or discord_accounts or webhook_accounts %}
+{% if not feeds or not has_destination %}
+<p class="empty-state">
+    You'll need
+    {% if not feeds and not has_destination %}at least one feed and one connected destination{% elif not feeds %}at least one feed{% else %}a connected destination{% endif %}
+    before you can create an echo.
+    {% if not feeds %}<a href="/feeds">Add a feed</a>{% endif %}
+    {% if not feeds and not has_destination %}&middot;{% endif %}
+    {% if not has_destination %}<a href="/accounts">Connect a destination</a>{% endif %}
+</p>
+{% else %}
 <form method="post" action="/api/echoes" class="echo-form">
     <div class="form-row">
         <label>Feed
@@ -187,6 +198,7 @@
     <input type="hidden" name="return_to" value="{{ return_to }}">
     <button type="submit">Create Echo</button>
 </form>
+{% endif %}
 
 {% if echoes %}
 <h2>Existing Echoes</h2>
@@ -280,7 +292,7 @@
     </tbody>
 </table>
 </div>
-{% else %}
+{% elif feeds and has_destination %}
 <p class="empty-state">No echoes yet. Create one above.</p>
 {% endif %}
 

--- a/tests/test_admin_mobile_actions.py
+++ b/tests/test_admin_mobile_actions.py
@@ -80,4 +80,4 @@ class TestAdminMobileActions:
 
     def test_cache_buster_bumped(self):
         base = (REPO_ROOT / "templates" / "base.html").read_text(encoding="utf-8")
-        assert 'style.css?v=56' in base
+        assert 'style.css?v=57' in base

--- a/tests/test_mobile_form_layout.py
+++ b/tests/test_mobile_form_layout.py
@@ -83,7 +83,7 @@ class TestMobileFormLayout:
 
     def test_cache_buster_bumped(self):
         base = (REPO_ROOT / "templates" / "base.html").read_text(encoding="utf-8")
-        assert 'style.css?v=56' in base, "CSS changed; bump the cache-buster so phones pick it up"
+        assert 'style.css?v=57' in base, "CSS changed; bump the cache-buster so phones pick it up"
 
     def test_smtp_test_email_label_is_visible(self):
         page = (REPO_ROOT / "templates" / "settings.html").read_text(encoding="utf-8")

--- a/tests/test_mobile_nav.py
+++ b/tests/test_mobile_nav.py
@@ -41,9 +41,11 @@ class TestMobileNavStructure:
         assert re.search(r"\.nav-brand\s*\{[^}]*order: 1", block, re.S)
         assert re.search(r"\.theme-toggle\s*\{[^}]*order: 2", block, re.S)
         assert re.search(r"\.nav-account\s*\{[^}]*order: 3", block, re.S)
-        # the tab strip is its own full-width row beneath them
-        assert re.search(r"\.nav-links\s*\{[^}]*order: 4", block, re.S, )
-        assert re.search(r"\.nav-links\s*\{[^}]*flex: 1 1 100%", block, re.S)
+        # the tab strip's row is .nav-links-wrap (a non-scrolling positioning
+        # context for the edge-fade cue); .nav-links itself is the inner
+        # scrolling strip and no longer carries order/flex-basis directly.
+        assert re.search(r"\.nav-links-wrap\s*\{[^}]*order: 4", block, re.S)
+        assert re.search(r"\.nav-links-wrap\s*\{[^}]*flex: 1 1 100%", block, re.S)
 
     def test_tab_strip_scrolls_horizontally(self):
         block = _nav_block()
@@ -51,6 +53,16 @@ class TestMobileNavStructure:
         assert "overflow-x: auto" in links_rule
         assert "flex-wrap: nowrap" in links_rule, "tabs must stay on one line, not wrap"
         assert "scrollbar-width: none" in links_rule
+
+    def test_nav_links_wrap_has_scroll_edge_fade(self):
+        """UX audit finding 2 (2026-09-08): a hidden scrollbar with zero other
+        cue meant History/Settings/How To could sit off-screen with nothing
+        indicating more tabs exist. .nav-links-wrap positions a fade at the
+        visible edge, fixed regardless of the inner strip's scroll offset."""
+        block = _nav_block()
+        wrap_rule = re.search(r"\.nav-links-wrap\s*\{([^}]*)\}", block, re.S).group(1)
+        assert "position: relative" in wrap_rule
+        assert re.search(r"\.nav-links-wrap::after\s*\{[^}]*position: absolute", block, re.S)
 
     def test_touch_targets_are_44px(self):
         block = _nav_block()
@@ -103,4 +115,4 @@ class TestNavTemplate:
         assert BASE_HTML.count('action="/logout"') == 2
 
     def test_cache_buster_bumped(self):
-        assert 'style.css?v=56' in BASE_HTML
+        assert 'style.css?v=57' in BASE_HTML

--- a/tests/test_trial_limits_visibility.py
+++ b/tests/test_trial_limits_visibility.py
@@ -170,7 +170,7 @@ class TestTrialLimitsOnDashboard:
         base = (Path(__file__).resolve().parent.parent / "templates" / "base.html").read_text(
             encoding="utf-8"
         )
-        assert 'style.css?v=56' in base
+        assert 'style.css?v=57' in base
 
 
 class TestBillingCtaSeam:

--- a/tests/test_ux_p1_fixes.py
+++ b/tests/test_ux_p1_fixes.py
@@ -60,7 +60,7 @@ class TestFocusVisibility:
     @pytest.mark.parametrize(
         ("selector", "line"),
         [
-            ("inline-form", ".inline-form input:focus {"),
+            ("inline-form", ".inline-form input:focus, .inline-form select:focus {"),
             ("form-row", ".form-row input:focus, .form-row select:focus, .form-row textarea:focus {"),
             ("auth-input", ".auth-input:focus {"),
         ],

--- a/tests/test_ux_p2_fixes.py
+++ b/tests/test_ux_p2_fixes.py
@@ -370,4 +370,4 @@ class TestAppJsP2:
 
     def test_asset_versions_bumped(self):
         base = _tpl("base.html")
-        assert 'style.css?v=56' in base and 'app.js?v=51' in base
+        assert 'style.css?v=57' in base and 'app.js?v=51' in base


### PR DESCRIPTION
## Summary

Implements fixes from a live-browser UX audit (`docs/reviews/2026-09-08-ux-interface-audit.md`, filed in this PR) — I registered a fresh account and walked the primary flows (landing → sign up → dashboard → Feeds → Accounts → Echoes → Reader, plus a 390px mobile viewport) in a real Chrome session rather than just reading templates. As with the previous three audit-fix PRs, one finding (native validation styling) was deliberately left out — see "Not in this PR" below.

- **Finding 2** (mobile nav, highest functional impact) — below 640px, the horizontally-scrollable tab strip had its scrollbar hidden with zero other cue that more tabs existed. At a 390px viewport, "Dashboard Feeds Reader Queue Accounts Echoes" exactly filled the visible strip and **History, Settings, and How To were completely invisible** (measured "History" rendering at x=494 in a 500px-wide viewport) — reachable only by an undiscoverable swipe. Added `.nav-links-wrap`, a non-scrolling wrapper that keeps a "more content" edge fade fixed at the visible boundary regardless of scroll position.
- **Finding 3** — the Echoes page showed two completely blank, unlabeled `<select>` dropdowns (confirmed via DOM: `options: []`) with zero guidance when no feeds/destinations existed yet — inconsistent with the Feeds and Accounts pages, which both handle their own empty state with a clear message. Now names exactly what's missing and links to `/feeds`/`/accounts`.
- **Finding 4** — a working "Or add Mastodon manually with a token" toggle rendered as plain, unstyled text with zero indication it was clickable. Added the same chevron treatment already used one level up for the account-type accordions.
- **Finding 5** — one `<select>` (the Feeds page's folder picker) had no CSS class, so it fell back to the OS-native control appearance next to styled text inputs. One-line fix: added `select` to `.inline-form`'s selector list, matching what `.form-row` already does.
- **Finding 6** — the feed URL field's placeholder text was truncated because every field in that row got an equal `flex: 1` share regardless of content length.
- **Finding 8** — two adjacent toggle-button groups on the Reader page used different visual languages for "currently selected" (solid fill vs. wash-tint outline). Aligned them.
- **Finding 1** (highest-priority finding, but a design judgment call) — `--hue-coral` (35°) sat only 10° from `--hue-red` (25°, danger) on the OKLCH wheel. I hit this myself on first load: the Sign Up button and the autofocused, empty email field's focus ring both read as an error state before I'd typed anything, and the dashboard's benign "Accounts: 0" stat inherits the same coral while "Feeds: 0" doesn't. **Isolated in its own commit** (shifts the hue to 50°, roughly midway between red and gold) specifically so it's trivial to revert or retune independently — this is a brand-color call, not a bug, and I'd like it reviewed on its own rather than bundled with the mechanical fixes.

## Not in this PR

- **Finding 7** (native browser validation styling — a generic OS tooltip breaking the app's otherwise custom design language): left as-is. Replacing it risks an accessibility regression (native `:invalid` messaging is well-handled by screen readers; a custom replacement needs its own `aria-live` and focus-management work) that's a bigger, more careful effort than this PR's other fixes warrant.
- Reader keyboard-shortcuts discoverability (noted as a positive-feature-with-a-caveat in the audit, not a defect): a content/onboarding decision, not a bug fix.

## Test plan

- [x] Full suite before any change: 1502 passed, 36 skipped (baseline).
- [x] Full suite after all changes: 1503 passed (one new test, `test_nav_links_wrap_has_scroll_edge_fade`), 36 skipped — no regressions.
- [x] Four pre-existing tests broke from the mobile-nav restructuring and the `.inline-form` selector change (order/overflow assertions in `test_mobile_nav.py`, a focus-rule text match in `test_ux_p1_fixes.py`, and four cache-buster version-string assertions) — updated to match the new, deliberate structure rather than reverting the fixes to avoid touching tests.
- [x] CSS verified brace-balanced (no syntax errors).
- [x] All nine primary routes verified to return 200 with no server-error markers, via a scripted register → browse session against a live local instance.
- [x] Echoes empty-state logic specifically verified across two states (no feed + no destination; feed added, no destination) by adding a real feed via the API and confirming the rendered message and links update correctly.
- [ ] **Not re-verified visually**: the Chrome session used for the initial audit disconnected mid-session while implementing fixes and didn't reconnect, so these changes were validated functionally (tests, curl, computed-style checks from the audit phase) but not re-screenshotted afterward. Worth a manual look before merging, particularly the color-hue change and the nav scroll-fade, since both are visual-only effects a functional test can't catch if wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ