### PR TITLE
fix(ui): add Discord/Webhook support to echo editing; fix reader load-more timestamps

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -285,12 +285,16 @@ function editEcho(echoId) {
     const blueskyOpts = document.getElementById('bluesky-options').innerHTML.trim();
     const microblogOpts = document.getElementById('microblog-options').innerHTML.trim();
     const matrixOpts = document.getElementById('matrix-options').innerHTML.trim();
+    const discordOpts = document.getElementById('discord-options').innerHTML.trim();
+    const webhookOpts = document.getElementById('webhook-options').innerHTML.trim();
 
     const mastoStyle = destType === 'mastodon' ? '' : 'display:none';
     const emailStyle = destType === 'email' ? '' : 'display:none';
     const blueskyStyle = destType === 'bluesky' ? '' : 'display:none';
     const microblogStyle = destType === 'microblog' ? '' : 'display:none';
     const matrixStyle = destType === 'matrix' ? '' : 'display:none';
+    const discordStyle = destType === 'discord' ? '' : 'display:none';
+    const webhookStyle = destType === 'webhook' ? '' : 'display:none';
 
     row.innerHTML = `<td colspan="5">
         <form method="post" action="/api/echoes/${echoId}/edit" class="echo-edit-form" aria-label="Edit echo">
@@ -305,6 +309,8 @@ function editEcho(echoId) {
                         ${blueskyOpts ? '<option value="bluesky"' + (destType === 'bluesky' ? ' selected' : '') + '>Bluesky Account</option>' : ''}
                         ${microblogOpts ? '<option value="microblog"' + (destType === 'microblog' ? ' selected' : '') + '>Micro.blog Blog</option>' : ''}
                         ${matrixOpts ? '<option value="matrix"' + (destType === 'matrix' ? ' selected' : '') + '>Matrix Room</option>' : ''}
+                        ${discordOpts ? '<option value="discord"' + (destType === 'discord' ? ' selected' : '') + '>Discord Channel</option>' : ''}
+                        ${webhookOpts ? '<option value="webhook"' + (destType === 'webhook' ? ' selected' : '') + '>Webhook</option>' : ''}
                     </select>
                 </label>
             </div>
@@ -339,6 +345,16 @@ function editEcho(echoId) {
             <div class="form-row" id="edit-matrix-fields-${echoId}" style="${matrixStyle}">
                 <label>Matrix Room
                     <select name="matrix_account_id">${matrixOpts}</select>
+                </label>
+            </div>
+            <div class="form-row" id="edit-discord-fields-${echoId}" style="${discordStyle}">
+                <label>Discord Channel
+                    <select name="discord_account_id">${discordOpts}</select>
+                </label>
+            </div>
+            <div class="form-row" id="edit-webhook-fields-${echoId}" style="${webhookStyle}">
+                <label>Webhook
+                    <select name="webhook_account_id">${webhookOpts}</select>
                 </label>
             </div>
             <div class="form-row">
@@ -406,6 +422,10 @@ function editEcho(echoId) {
     if (microblogSelect) microblogSelect.value = destId;
     const matrixSelect = row.querySelector('select[name="matrix_account_id"]');
     if (matrixSelect) matrixSelect.value = destId;
+    const discordSelect = row.querySelector('select[name="discord_account_id"]');
+    if (discordSelect) discordSelect.value = destId;
+    const webhookSelect = row.querySelector('select[name="webhook_account_id"]');
+    if (webhookSelect) webhookSelect.value = destId;
 
     // Sync conditional rows to the echo's current delivery mode: without this
     // a digest echo opens showing both "batch into one email" and "Max posts
@@ -424,6 +444,8 @@ function toggleEditDest(echoId) {
     document.getElementById(`edit-bluesky-fields-${echoId}`).style.display = destType === 'bluesky' ? '' : 'none';
     document.getElementById(`edit-microblog-fields-${echoId}`).style.display = destType === 'microblog' ? '' : 'none';
     document.getElementById(`edit-matrix-fields-${echoId}`).style.display = destType === 'matrix' ? '' : 'none';
+    document.getElementById(`edit-discord-fields-${echoId}`).style.display = destType === 'discord' ? '' : 'none';
+    document.getElementById(`edit-webhook-fields-${echoId}`).style.display = destType === 'webhook' ? '' : 'none';
     const digestFields = document.getElementById(`edit-digest-fields-${echoId}`);
     if (digestFields) digestFields.style.display = destType === 'email' ? '' : 'none';
     const dripFields = document.getElementById(`edit-drip-fields-${echoId}`);
@@ -1580,7 +1602,7 @@ async function readerLoadMore(btn) {
         }
 
         // Hydrate timestamps and trigger auto-read if active
-        if (typeof hydrateLocalTimes === 'function') hydrateLocalTimes();
+        if (typeof formatLocalTimes === 'function') formatLocalTimes();
         if (readerAutoReadActive && typeof readerAutoReadScroll === 'function') {
             readerAutoReadScroll();
         }

--- a/tests/test_echo_editor_dest_types.py
+++ b/tests/test_echo_editor_dest_types.py
@@ -1,0 +1,183 @@
+"""Fixes from docs/reviews/2026-09-09-bug-review.md findings #2 and #23.
+
+#2  (Critical): editEcho()/toggleEditDest() in static/js/app.js built
+    destination-type <option> lists and field-visibility toggles for
+    mastodon/email/bluesky/microblog/matrix only. Discord and Webhook
+    echoes had no branch at all, so opening "Edit" on one of them
+    silently fell back to whatever destination type happened to be
+    first in the list (typically mastodon) — saving the edit then
+    either reassigned the echo to the wrong destination or failed with
+    a 400 "Invalid destination type".
+
+#23 (Low): readerLoadMore() called a nonexistent `hydrateLocalTimes`
+    function (guarded by `typeof ... === 'function'`, so it silently
+    no-opped every time). The real function is `formatLocalTimes`.
+    Items appended via the Reader's "Load more" button never got their
+    <time class="local-time"> elements converted to the viewer's local
+    time/locale.
+"""
+
+import re
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import auth
+import database
+import security
+import settings
+from app import app
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+APP_JS = (REPO_ROOT / "static" / "js" / "app.js").read_text(encoding="utf-8")
+
+
+def _tpl(name: str) -> str:
+    return (REPO_ROOT / "templates" / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# #2. editEcho()/toggleEditDest() must handle discord and webhook
+# ---------------------------------------------------------------------------
+
+
+class TestEditEchoDiscordWebhookSupport:
+    def test_no_hydrateLocalTimes_references_left(self):
+        assert "hydrateLocalTimes" not in APP_JS
+
+    def test_edit_echo_reads_discord_and_webhook_option_templates(self):
+        # Mirrors mastoOpts/emailOpts/... pulled from the server-rendered
+        # #<type>-options <script> blocks in templates/echoes.html.
+        assert "document.getElementById('discord-options')" in APP_JS
+        assert "document.getElementById('webhook-options')" in APP_JS
+
+    def test_edit_echo_builds_discord_and_webhook_select_options(self):
+        assert '<option value="discord"' in APP_JS
+        assert '<option value="webhook"' in APP_JS
+        assert "Discord Channel</option>" in APP_JS
+        assert ">Webhook</option>" in APP_JS
+
+    def test_edit_echo_has_discord_and_webhook_field_containers(self):
+        assert 'id="edit-discord-fields-${echoId}"' in APP_JS
+        assert 'id="edit-webhook-fields-${echoId}"' in APP_JS
+        assert 'name="discord_account_id"' in APP_JS
+        assert 'name="webhook_account_id"' in APP_JS
+
+    def test_edit_echo_sets_selected_value_for_discord_and_webhook(self):
+        assert 'row.querySelector(\'select[name="discord_account_id"]\')' in APP_JS
+        assert 'row.querySelector(\'select[name="webhook_account_id"]\')' in APP_JS
+
+    def test_toggle_edit_dest_shows_hides_discord_and_webhook_fields(self):
+        m = re.search(r"function toggleEditDest\(echoId\) \{.*?\n\}", APP_JS, re.S)
+        assert m, "toggleEditDest() not found"
+        body = m.group(0)
+        assert "edit-discord-fields-${echoId}`).style.display = destType === 'discord'" in body
+        assert "edit-webhook-fields-${echoId}`).style.display = destType === 'webhook'" in body
+
+    def test_readerLoadMore_calls_the_real_formatLocalTimes(self):
+        m = re.search(r"async function readerLoadMore\(btn\) \{.*?\n\}", APP_JS, re.S)
+        assert m, "readerLoadMore() not found"
+        body = m.group(0)
+        assert "formatLocalTimes()" in body
+
+
+# ---------------------------------------------------------------------------
+# Live route coverage: editing a discord/webhook echo round-trips cleanly.
+# ---------------------------------------------------------------------------
+
+DISCORD_WEBHOOK_URL = (
+    "https://discord.com/api/webhooks/1234567890123456789/"
+    "token_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
+
+
+@pytest.fixture()
+def multi_client(monkeypatch, db_tmp):
+    """Signed-in multi-mode TestClient over the temp DB (mirrors test_discord.py)."""
+    monkeypatch.setattr(settings, "MULTI", True)
+    monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "AUTH_TOKEN", None)
+    monkeypatch.setattr(settings, "DATABASE_URL", "")
+    monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)
+    auth._login_attempts.clear()
+    auth._register_attempts.clear()
+
+    uid = 7
+    with database.get_db() as db:
+        db.execute(
+            "INSERT INTO users (id, email, password_hash, email_verified)"
+            " VALUES (?, 'edituser@example.com', '', 1)",
+            (uid,),
+        )
+    client = TestClient(app)
+    client.cookies.set("feedecho_session", security.sign_session(uid, "edituser@example.com"))
+    return client
+
+
+class TestEditingDiscordEchoServerSide:
+    def test_echoes_page_serves_discord_and_webhook_option_templates(self, multi_client):
+        with mock.patch(
+            "app.discord_connect",
+            return_value={"webhook_url": DISCORD_WEBHOOK_URL, "name": "Feed Bot", "channel_id": "1"},
+        ):
+            multi_client.post(
+                "/api/discord-accounts",
+                data={"webhook_url": DISCORD_WEBHOOK_URL},
+                follow_redirects=False,
+            )
+        with database.get_db() as db:
+            db.execute(
+                "INSERT INTO feeds (id, name, url, user_id) VALUES (1, 'f', 'https://example.com/feed', 7)"
+            )
+            db.execute(
+                "INSERT INTO echoes (id, feed_id, destination_type, destination_id, template, user_id)"
+                " VALUES (1, 1, 'discord', 1, '{{ title }}', 7)"
+            )
+        r = multi_client.get("/echoes")
+        assert r.status_code == 200
+        # The edit-dropdown option template the fixed editEcho() now reads.
+        assert 'id="discord-options"' in r.text
+        assert 'id="webhook-options"' in r.text
+        assert "Feed Bot" in r.text
+
+    def test_edit_discord_echo_keeps_discord_destination(self, multi_client):
+        """Regression for finding #2: saving an edited discord echo (with the
+        destination_type the client would now correctly keep selected) must
+        not be rejected and must not silently reassign it to another type.
+        """
+        with mock.patch(
+            "app.discord_connect",
+            return_value={"webhook_url": DISCORD_WEBHOOK_URL, "name": "Feed Bot", "channel_id": "1"},
+        ):
+            multi_client.post(
+                "/api/discord-accounts",
+                data={"webhook_url": DISCORD_WEBHOOK_URL},
+                follow_redirects=False,
+            )
+        with database.get_db() as db:
+            db.execute(
+                "INSERT INTO feeds (id, name, url, user_id) VALUES (1, 'f', 'https://example.com/feed', 7)"
+            )
+            db.execute(
+                "INSERT INTO echoes (id, feed_id, destination_type, destination_id, template, user_id)"
+                " VALUES (1, 1, 'discord', 1, '{{ title }}', 7)"
+            )
+        r = multi_client.post(
+            "/api/echoes/1/edit",
+            data={
+                "feed_id": "1",
+                "destination_type": "discord",
+                "discord_account_id": "1",
+                "template": "{{ title }} {{ link }}",
+            },
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        with database.get_db() as db:
+            row = db.execute(
+                "SELECT destination_type, destination_id FROM echoes WHERE id = 1"
+            ).fetchone()
+        assert row["destination_type"] == "discord"
+        assert row["destination_id"] == 1


### PR DESCRIPTION
## Summary
- `editEcho()`/`toggleEditDest()` in `static/js/app.js` only handled mastodon/email/bluesky/microblog/matrix when building the destination-type `<select>` options and per-destination field visibility for the inline echo editor, even though the create-echo form (`templates/echoes.html`) and the server (`app.py`, `VALID_DEST_TYPES`) both fully support `discord` and `webhook` destinations. Editing an existing Discord or Webhook echo silently fell back to whichever destination type happened to be first in the list — saving either reassigned the echo to the wrong destination or failed with a 400 "Invalid destination type". Fixed by adding `discordOpts`/`webhookOpts` lookups (from the already-existing `#discord-options`/`#webhook-options` script templates), `<option>` entries, `edit-discord-fields-${echoId}`/`edit-webhook-fields-${echoId}` containers, selected-value wiring, and visibility toggling in `toggleEditDest()` — mirroring the existing pattern for the other five destination types exactly.
- `readerLoadMore()` called a nonexistent `hydrateLocalTimes()` (silently no-opping behind a `typeof` guard) instead of the real `formatLocalTimes()`, so items appended via the Reader's "Load more" button never got their `<time class="local-time">` elements converted to the viewer's local time/locale. Fixed the call site.

Fixes docs/reviews/2026-09-09-bug-review.md findings #2 and #23.

## Test plan
- [x] Added `tests/test_echo_editor_dest_types.py`: markup-presence assertions on `static/js/app.js` (following the pattern in `tests/test_ux_p3_fixes.py`) confirming `editEcho()`/`toggleEditDest()` now reference discord/webhook option templates, build the right `<option>`/field-container markup, and that `readerLoadMore()` calls `formatLocalTimes()` with no `hydrateLocalTimes` references left; plus a live route test that connects a Discord webhook account, creates a discord echo, and confirms POSTing `/api/echoes/{id}/edit` with `destination_type=discord` round-trips (303, destination stays `discord`) rather than being silently reassigned or rejected.
- [x] `node --check static/js/app.js` passes.
- [x] Full suite: `FEEDECHO_MODE=single /tmp/feedecho-shared-venv/bin/python -m pytest -m "not pg and not multi" -q` → 1471 passed, 1 skipped, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ