### PR TITLE
fix(security): eliminate inline-JS string-breakout XSS in admin & folder confirm dialogs

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1626,3 +1626,54 @@ function adminConfirmDelete(form) {
     }
     return confirm('Permanently delete ' + email + ' and ALL their data (feeds, echoes, destinations, post history)? This cannot be undone.');
 }
+
+// The admin action forms below all follow the same safety pattern as
+// adminConfirmDelete: the user's email (attacker-controlled at registration
+// time) travels through a data-* attribute, which Jinja autoescapes into a
+// safe HTML attribute value. We read it here with .dataset and build the
+// confirm() text via plain string concatenation, so it is never re-parsed as
+// JS the way a template-generated inline onsubmit string would be.
+
+function adminConfirmSuspend(form) {
+    var email = (form.dataset.email || '').trim();
+    return confirm('Suspend ' + email + '? Their feeds stop posting until unsuspended.');
+}
+
+function adminConfirmRemoveAdmin(form) {
+    var email = (form.dataset.email || '').trim();
+    return confirm('Remove admin access from ' + email + '?');
+}
+
+function adminConfirmMakeAdmin(form) {
+    var email = (form.dataset.email || '').trim();
+    return confirm('Make ' + email + ' an admin? They gain full operator access, including user and invite management.');
+}
+
+function adminConfirmSetPlan(form) {
+    var email = (form.dataset.email || '').trim();
+    var plan = (form.plan || {}).value || '';
+    return confirm('Set plan for ' + email + ' to ' + plan + '? This changes their access and billing.');
+}
+
+function adminConfirmExtendTrial(form) {
+    var email = (form.dataset.email || '').trim();
+    var days = (form.days || {}).value || '';
+    return confirm('Extend ' + email + '\'s trial by ' + days + ' day(s)?');
+}
+
+// Folder rename/delete confirm dialogs follow the same pattern: the folder
+// name (free text the owner chose) comes in via data-folder-name rather than
+// being interpolated straight into the inline onsubmit JS string.
+
+function folderConfirmRename(form) {
+    var name = (form.dataset.folderName || '').trim();
+    var n = prompt('Rename folder:', name);
+    if (!n) return false;
+    form.name.value = n;
+    return true;
+}
+
+function folderConfirmDelete(form) {
+    var name = (form.dataset.folderName || '').trim();
+    return confirm('Delete folder \'' + name + '\'? Feeds inside will become uncategorized.');
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -65,23 +65,27 @@
                     </form>
                     {% else %}
                     <form method="post" action="/admin/users/{{ u.id }}/suspend" class="inline-form"
-                          onsubmit="return confirm('Suspend {{ u.email }}? Their feeds stop posting until unsuspended.')">
+                          data-email="{{ u.email }}"
+                          onsubmit="return adminConfirmSuspend(this)">
                         <button type="submit" class="btn-sm btn-danger">Suspend</button>
                     </form>
                     {% endif %}
                     {% if u.is_admin %}
                     <form method="post" action="/admin/users/{{ u.id }}/demote" class="inline-form"
-                          onsubmit="return confirm('Remove admin access from {{ u.email }}?')">
+                          data-email="{{ u.email }}"
+                          onsubmit="return adminConfirmRemoveAdmin(this)">
                         <button type="submit" class="btn-sm btn-danger">Remove admin</button>
                     </form>
                     {% else %}
                     <form method="post" action="/admin/users/{{ u.id }}/promote" class="inline-form"
-                          onsubmit="return confirm('Make {{ u.email }} an admin? They gain full operator access, including user and invite management.')">
+                          data-email="{{ u.email }}"
+                          onsubmit="return adminConfirmMakeAdmin(this)">
                         <button type="submit" class="btn-sm">Make admin</button>
                     </form>
                     {% endif %}
                     <form method="post" action="/admin/users/{{ u.id }}/plan" class="inline-form"
-                          onsubmit="return confirm('Set plan for {{ u.email }} to ' + this.plan.value + '? This changes their access and billing.')">
+                          data-email="{{ u.email }}"
+                          onsubmit="return adminConfirmSetPlan(this)">
                         <label class="sr-only" for="plan-{{ u.id }}">Plan</label>
                         <select name="plan" id="plan-{{ u.id }}" class="btn-sm">
                             {% for p in plan_names %}
@@ -92,7 +96,8 @@
                     </form>
                     {% if u.plan == 'trial' %}
                     <form method="post" action="/admin/users/{{ u.id }}/extend-trial" class="inline-form"
-                          onsubmit="return confirm('Extend {{ u.email }}'s trial by ' + this.days.value + ' day(s)?')">
+                          data-email="{{ u.email }}"
+                          onsubmit="return adminConfirmExtendTrial(this)">
                         <label class="sr-only" for="extend-{{ u.id }}">Days</label>
                         <input type="number" name="days" id="extend-{{ u.id }}" min="1" max="365" value="14" style="width: 4.5rem;">
                         <button type="submit" class="btn-sm">Extend trial</button>

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -34,11 +34,15 @@
             <li style="display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.4rem 0.6rem; background: var(--surface-light); border-radius: 6px;">
                 <span style="font-weight: 600;">📁 {{ folder.name }}</span>
                 <span style="display: inline-flex; gap: 0.4rem;">
-                    <form method="post" action="/api/folders/{{ folder.id }}/rename" class="inline" onsubmit="var n = prompt('Rename folder:', '{{ folder.name | e }}'); if (!n) return false; this.name.value = n;">
+                    <form method="post" action="/api/folders/{{ folder.id }}/rename" class="inline"
+                          data-folder-name="{{ folder.name }}"
+                          onsubmit="return folderConfirmRename(this)">
                         <input type="hidden" name="name" value="">
                         <button type="submit" class="btn-sm">Rename</button>
                     </form>
-                    <form method="post" action="/api/folders/{{ folder.id }}/delete" class="inline" onsubmit="return confirm('Delete folder \'{{ folder.name | e }}\'? Feeds inside will become uncategorized.');">
+                    <form method="post" action="/api/folders/{{ folder.id }}/delete" class="inline"
+                          data-folder-name="{{ folder.name }}"
+                          onsubmit="return folderConfirmDelete(this)">
                         <button type="submit" class="btn-sm btn-danger">Delete</button>
                     </form>
                 </span>

--- a/tests/test_admin_xss_fix.py
+++ b/tests/test_admin_xss_fix.py
@@ -1,0 +1,175 @@
+"""Regressions for the inline-JS string-breakout XSS fix in admin/folder
+confirm dialogs (docs/reviews/2026-09-09-bug-review.md findings #1, #20, #21).
+
+Before the fix, several `onsubmit="return confirm('... {{ u.email }} ...')"`
+attributes interpolated untrusted, Jinja-autoescaped user data directly into
+an inline JS string. Because the browser HTML-decodes attribute values
+*before* compiling the inline handler as JS, a quote/apostrophe in the email
+(or folder name) could break out of the JS string literal and execute
+arbitrary JS in the viewer's session. The fix moves the untrusted value into
+a `data-*` attribute (which Jinja autoescape does make safe there) and reads
+it back with `element.dataset` in static/js/app.js, building the confirm()
+text via plain string concatenation instead of template interpolation.
+
+These tests assert the *shape* of the rendered HTML (data-attribute present,
+vulnerable inline-interpolation pattern absent) rather than executing JS in
+a browser, matching how this repo tests template output elsewhere.
+"""
+
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+import database
+import security
+import settings
+from app import app
+
+ADMIN_ID = 20
+EVIL_ID = 21
+
+EVIL_EMAIL = "x'-alert(1)-'@a.co"
+
+
+@pytest.fixture
+def admin_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "MULTI", True)
+    monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "AUTH_TOKEN", None)
+    monkeypatch.setattr(settings, "DATABASE_URL", "")
+    monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "admin-xss.db")
+    database.init_db()
+    with database.get_db() as db:
+        db.execute(
+            "INSERT INTO users (id, email, password_hash, is_admin)"
+            " VALUES (?, 'admin@example.com', '', 1)",
+            (ADMIN_ID,),
+        )
+        # Registration only rejects '@', whitespace, and CR/LF in the local
+        # part (utils.EMAIL_RE) -- quotes and parens are allowed through, so
+        # this is a realistic attacker-controlled value, inserted directly
+        # here the same way test_admin_dashboard.py seeds users.
+        db.execute(
+            "INSERT INTO users (id, email, password_hash, is_admin, plan)"
+            " VALUES (?, ?, '', 0, 'trial')",
+            (EVIL_ID, EVIL_EMAIL),
+        )
+    return settings
+
+
+def _admin_client():
+    c = TestClient(app)
+    c.cookies.set("feedecho_session", security.sign_session(ADMIN_ID, "admin@example.com"))
+    return c
+
+
+class TestAdminEmailXss:
+    def test_evil_email_never_appears_inside_inline_onsubmit(self, admin_env):
+        with _admin_client() as c:
+            resp = c.get("/admin")
+        assert resp.status_code == 200
+        html = resp.text
+
+        # The raw email must never sit inside an onsubmit="...confirm(...)"
+        # attribute anywhere in the page -- that was the vulnerable pattern.
+        for m in re.finditer(r'onsubmit="([^"]*)"', html):
+            assert EVIL_EMAIL not in m.group(1), (
+                "attacker email leaked into an inline onsubmit handler: "
+                + m.group(1)
+            )
+            # Also guard against the raw apostrophe/quote fragments landing
+            # there even if the rest of the email were stripped somehow.
+            assert "'-alert(1)-'" not in m.group(1)
+
+        # It must instead show up only as a data-email attribute value,
+        # where Jinja autoescaping keeps it a safe, inert string.
+        assert 'data-email="x&#39;-alert(1)-&#39;@a.co"' in html or (
+            'data-email="' in html and EVIL_EMAIL.replace("'", "&#39;") in html
+        )
+
+    def test_admin_action_forms_use_data_email_and_js_helpers(self, admin_env):
+        with _admin_client() as c:
+            resp = c.get("/admin")
+        html = resp.text
+
+        # Each of the five forms named in the finding must have moved to
+        # the data-attribute + dedicated-JS-function pattern.
+        for fn in (
+            "adminConfirmSuspend",
+            "adminConfirmRemoveAdmin",
+            "adminConfirmMakeAdmin",
+            "adminConfirmSetPlan",
+            "adminConfirmExtendTrial",
+        ):
+            assert f"onsubmit=\"return {fn}(this)\"" in html
+
+        # None of the old Jinja-interpolated-into-JS-string patterns remain.
+        assert "onsubmit=\"return confirm('Suspend " not in html
+        assert "onsubmit=\"return confirm('Remove admin access from " not in html
+        assert "onsubmit=\"return confirm('Make " not in html
+        assert "onsubmit=\"return confirm('Set plan for " not in html
+        assert "onsubmit=\"return confirm('Extend " not in html
+
+    def test_extend_trial_js_has_no_bare_unescaped_apostrophe(self):
+        # Finding #2: the *static* template text itself had a bare
+        # apostrophe ("{{ u.email }}'s trial") that broke the JS string on
+        # every render, regardless of email content. Assert the app.js
+        # helper builds that text via safe concatenation instead.
+        with open("static/js/app.js", encoding="utf-8") as f:
+            js = f.read()
+        m = re.search(
+            r"function adminConfirmExtendTrial\(form\)\s*\{(.*?)\n\}",
+            js,
+            re.S,
+        )
+        assert m, "adminConfirmExtendTrial helper not found in app.js"
+        body = m.group(1)
+        # The apostrophe must appear only inside a JS string literal built
+        # by concatenation (immediately preceded by a `+ '...` piece), not
+        # embedded raw in a template-interpolated identifier.
+        assert "trial by " in body
+        assert "\\'s trial by" in body or "'s trial by" in body
+        # Sanity: the helper is syntactically well-formed JS -- balanced
+        # quotes on the confirm() line once escaped apostrophes (\') are
+        # discounted, since those are literal characters inside a string,
+        # not delimiters.
+        confirm_line = next(line for line in body.splitlines() if "confirm(" in line)
+        unescaped = confirm_line.replace("\\'", "")
+        assert unescaped.count("'") % 2 == 0
+
+
+class TestFolderNameXss:
+    @pytest.fixture
+    def single_env(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(settings, "MULTI", False)
+        monkeypatch.setattr(settings, "AUTH_TOKEN", None)
+        monkeypatch.setattr(settings, "DATABASE_URL", "")
+        monkeypatch.setattr(database, "DB_PATH", tmp_path / "folder-xss.db")
+        database.init_db()
+        import scheduler
+
+        monkeypatch.setattr(scheduler, "fetch_feed", lambda url: {"items": []})
+        return settings
+
+    def test_evil_folder_name_never_appears_inside_inline_onsubmit(self, single_env):
+        client = TestClient(app)
+        evil_name = "a'-alert(1)-'"
+        r = client.post("/api/folders", data={"name": evil_name}, follow_redirects=False)
+        assert r.status_code == 303
+
+        resp = client.get("/feeds")
+        assert resp.status_code == 200
+        html = resp.text
+
+        for m in re.finditer(r'onsubmit="([^"]*)"', html):
+            assert evil_name not in m.group(1)
+            assert "'-alert(1)-'" not in m.group(1)
+
+        assert "data-folder-name=" in html
+        assert 'onsubmit="return folderConfirmRename(this)"' in html
+        assert 'onsubmit="return folderConfirmDelete(this)"' in html
+        # Old vulnerable patterns are gone.
+        assert "var n = prompt('Rename folder:', '" not in html
+        assert "confirm('Delete folder \\'" not in html

--- a/tests/test_ux_p2_fixes.py
+++ b/tests/test_ux_p2_fixes.py
@@ -200,20 +200,27 @@ class TestSettingsPage:
 
 class TestAdminPage:
     def test_destructive_actions_confirm(self):
+        # Destructive/privileged actions still gate on a confirm() dialog,
+        # but the email/plan/days values that used to be interpolated
+        # straight into the inline onsubmit JS string now travel through a
+        # data-email attribute (Jinja-autoescaped) and are read back by a
+        # dedicated JS helper in static/js/app.js -- see the XSS fix in
+        # tests/test_admin_xss_fix.py for why (string-breakout XSS via a
+        # crafted email/folder name).
         page = _tpl("admin.html")
         suspend_form = re.search(r'<form[^>]*action="/admin/users/\{\{ u\.id \}\}/suspend"[^>]*>', page)
-        assert suspend_form and "confirm(" in suspend_form.group(0)
+        assert suspend_form and "adminConfirmSuspend(this)" in suspend_form.group(0)
         demote_form = re.search(r'<form[^>]*action="/admin/users/\{\{ u\.id \}\}/demote"[^>]*>', page)
-        assert demote_form and "confirm(" in demote_form.group(0)
+        assert demote_form and "adminConfirmRemoveAdmin(this)" in demote_form.group(0)
         revoke_form = re.search(r'<form[^>]*action="/admin/invites/revoke"[^>]*>', page)
         assert revoke_form and "confirm(" in revoke_form.group(0)
         # privilege/billing actions confirm too (impeccable critique P3)
         promote_form = re.search(r'<form[^>]*action="/admin/users/\{\{ u\.id \}\}/promote"[^>]*>', page)
-        assert promote_form and "confirm(" in promote_form.group(0)
+        assert promote_form and "adminConfirmMakeAdmin(this)" in promote_form.group(0)
         plan_form = re.search(r'<form[^>]*action="/admin/users/\{\{ u\.id \}\}/plan"[^>]*>', page)
-        assert plan_form and "confirm(" in plan_form.group(0)
+        assert plan_form and "adminConfirmSetPlan(this)" in plan_form.group(0)
         extend_form = re.search(r'<form[^>]*action="/admin/users/\{\{ u\.id \}\}/extend-trial"[^>]*>', page)
-        assert extend_form and "confirm(" in extend_form.group(0)
+        assert extend_form and "adminConfirmExtendTrial(this)" in extend_form.group(0)
         # reversible actions stay one-click
         unsuspend_form = re.search(r'<form[^>]*action="/admin/users/\{\{ u\.id \}\}/unsuspend"[^>]*>', page)
         assert unsuspend_form and "confirm(" not in unsuspend_form.group(0)


### PR DESCRIPTION
## Summary

- **Finding 1 (Critical) — Stored XSS in the admin panel.** Five `templates/admin.html` forms (Suspend/Unsuspend, Remove admin, Make admin, Set plan, Extend trial) used `onsubmit="return confirm('... {{ u.email }} ...')"`. Jinja autoescapes `u.email`'s quotes to HTML entities, but the browser HTML-decodes attribute values *before* compiling the inline handler as JS — so an email like `x'-alert(1)-'@a.co` (which passes registration: `utils.EMAIL_RE` only excludes `@`, whitespace, and CR/LF from the local part) breaks out of the JS string. Any admin clicking one of these buttons on a maliciously-registered account's row would run attacker JS in the admin's session (session-cookie theft, or a same-origin `fetch()` to self-promote to admin — these POSTs have no CSRF token).
- **Finding 2 (Medium) — Extend-trial `confirm()` never appears.** The extend-trial `onsubmit` had a bare, unescaped apostrophe in the static template text itself ("`{{ u.email }}'s trial`"), which broke the JS string on every render regardless of email content.
- **Finding 3 (Medium) — Same pattern in folder rename/delete (self-XSS).** `templates/feeds.html`'s folder rename/delete forms interpolated `folder.name | e` into inline `prompt()`/`confirm()` calls the same unsafe way. Folder names are free text (60-char max, no character restriction), so a folder named e.g. `a'-alert(1)-'` broke out of the JS string when its owner clicked Rename/Delete — self-XSS only, since folders aren't shown to other users.

**Fix:** followed the pattern already used by the existing delete-user form (`data-email` + `adminConfirmDelete(form)` in `static/js/app.js`). Moved every untrusted value into a `data-*` attribute (safe under Jinja autoescaping in that context) and added dedicated JS helpers — `adminConfirmSuspend`, `adminConfirmRemoveAdmin`, `adminConfirmMakeAdmin`, `adminConfirmSetPlan`, `adminConfirmExtendTrial`, `folderConfirmRename`, `folderConfirmDelete` — that read `element.dataset` and build the `confirm()`/`prompt()` text via plain JS string concatenation instead of template interpolation. This also naturally fixes the extend-trial apostrophe bug (Finding 2), since the text is now built correctly in JS: `"Extend " + email + "'s trial by " + days + " day(s)?"`.

Ref: docs/reviews/2026-09-09-bug-review.md findings #1, #20, #21.

## Test plan

- Added `tests/test_admin_xss_fix.py`: registers a user with a quote-containing email directly via the DB fixture (matching `test_admin_dashboard.py` conventions) and a folder with a quote-containing name, renders the admin page and feeds page, and asserts:
  - the raw untrusted value never appears inside an `onsubmit="..."` attribute anywhere in the page (old vulnerable pattern is gone),
  - it appears only as a safely-autoescaped `data-email` / `data-folder-name` attribute,
  - each form's `onsubmit` now calls the corresponding dedicated JS helper,
  - the `adminConfirmExtendTrial` JS helper builds syntactically well-formed, balanced-quote JS.
- Updated `tests/test_ux_p2_fixes.py::TestAdminPage::test_destructive_actions_confirm`, which previously asserted the literal (now-removed) inline `confirm(` pattern on each form tag — updated to assert the new `adminConfirm*(this)` handler calls instead, preserving the underlying invariant that these actions still require confirmation.
- Ran the full suite: `FEEDECHO_MODE=single /tmp/feedecho-shared-venv/bin/python -m pytest -m "not pg and not multi" -q` → **1466 passed, 1 skipped, 118 deselected**, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ