### PR TITLE
fix(email): sanitize CRLF from feed-item titles before use as email Subject

### DIFF
--- a/email_sender.py
+++ b/email_sender.py
@@ -7,6 +7,7 @@ verification, password reset).
 
 import html
 import logging
+import re
 import smtplib
 import ssl
 from email.mime.image import MIMEImage
@@ -132,7 +133,17 @@ def _send_via(cfg: dict, to_email: str, subject: str, body: str, images: list[di
 
     root["From"] = f"{from_name} <{from_email}>"
     root["To"] = to_email
-    root["Subject"] = subject
+    # Subject is built from untrusted feed content (an item title), unlike
+    # the other header-bound fields above, which are validated against
+    # embedded CR/LF at save time (see app.py's SMTP settings validation and
+    # utils.EMAIL_RE). email.mime's compat32 policy raises HeaderParseError/
+    # HeaderWriteError on serialization if a header value contains a raw
+    # \r or \n, so an unsanitized title with an embedded newline (e.g. from
+    # a CDATA title) would connect to and authenticate against the SMTP
+    # server, then blow up on root.as_string() below — identically on every
+    # retry, permanently breaking delivery for that item. Strip it here so
+    # this is defended regardless of caller.
+    root["Subject"] = re.sub(r"[\r\n]+", " ", subject)
 
     # Plain text version (template output is plain text)
     alternative.attach(MIMEText(body, "plain"))

--- a/tests/test_email_images.py
+++ b/tests/test_email_images.py
@@ -305,6 +305,36 @@ class TestEmailSenderMime:
         # Alt text is escaped too, including quotes.
         assert 'alt="&quot;&gt;&lt;script&gt;"' in html_text
 
+    def test_subject_with_embedded_crlf_is_sanitized(self, fake_smtp):
+        """A feed-item title containing raw CR/LF must not blow up as_string().
+
+        Python's email.mime (compat32 policy) raises HeaderParseError /
+        HeaderWriteError when a header value contains an embedded \\r or \\n,
+        which previously meant a malicious/malformed feed title (e.g. from a
+        CDATA title with an embedded newline) would connect to and
+        authenticate against the SMTP server, then fail on serialization —
+        identically on every retry, permanently breaking delivery for that
+        item. The subject must be sanitized so the header is well-formed and
+        the send still goes through.
+        """
+        import email_sender
+
+        malicious_subject = "Breaking News\r\nBcc: evil@example.com\r\nMore text"
+        email_sender._send_via(
+            _cfg(), "to@example.com", malicious_subject, "Hello"
+        )
+
+        # Must not raise, and the CR/LF must be gone from the header value.
+        msg = _parse_messages()[0]
+        subject_header = msg.get("Subject")
+        assert "\r" not in subject_header
+        assert "\n" not in subject_header
+        # Content is preserved (replaced with spaces), not silently dropped
+        # or truncated to something unrelated.
+        assert "Breaking News" in subject_header
+        assert "Bcc: evil@example.com" in subject_header
+        assert "More text" in subject_header
+
     def test_send_email_passes_images_through(self, monkeypatch):
         """send_email forwards the images kwarg to _send_via."""
         import email_sender


### PR DESCRIPTION
## Summary

`email_sender.py`'s `_send_via` assigns `root["Subject"] = subject` directly from a per-send subject built in `scheduler.py` from an untrusted feed item title (`subject=truncate(item.get("title") or item.get("link") or "FeedEcho: New Post", 200)`), unlike every other header-bound field in this codebase — SMTP host/username/from-name/from-email are validated against `[\r\n]` at save time in `app.py`, and the `To` address goes through `utils.EMAIL_RE` (which also excludes `\r\n`).

This is **not an exploitable header-injection/Bcc-smuggling vector**: Python's `email.mime` machinery under the compat32 policy already refuses to serialize a header value containing an embedded `\r`/`\n` — `root.as_string()` raises `HeaderParseError`/`HeaderWriteError` before anything malformed hits the wire. Confirmed empirically before implementing the fix.

It **is** a real availability bug, though. A feed item whose title contains a raw `\r`/`\n` (e.g. a CDATA title with an embedded newline) causes `_send_via` to connect to and authenticate against the SMTP server, then throw while serializing the message inside the actual `sendmail(...)` call. Since the title never changes between retries, every retry attempt fails identically, forever — permanently breaking delivery for that specific item, surfacing only as a generic "Email delivery failed" with no hint that the real cause is a malformed title.

**Fix**: sanitize `subject` right before assigning it to the `Subject` header in `email_sender.py` (`re.sub(r"[\r\n]+", " ", subject)`), matching the sanitization pattern already used for the other header-bound fields. Fixed at the point of use in `_send_via` (rather than at the `scheduler.py` call site) so any future caller of this function is protected too.

Reference: `docs/reviews/2026-09-09-bug-review.md` finding #11.

## Test plan

- Added `TestEmailSenderMime.test_subject_with_embedded_crlf_is_sanitized` in `tests/test_email_images.py`, which calls `email_sender._send_via` with a subject containing embedded `\r\n` and asserts (1) no exception is raised during serialization, and (2) the resulting `Subject` header has the CR/LF stripped (replaced with spaces) while the rest of the content is preserved, not truncated.
- Wrote and ran a throwaway script constructing a `MIMEMultipart`/`MIMEText` with a `\r\n`-containing subject and calling `.as_string()` to confirm the pre-fix `HeaderParseError` before implementing the change.
- Full suite: `FEEDECHO_MODE=single /tmp/feedecho-shared-venv/bin/python -m pytest -m "not pg and not multi" -q` — 1463 passed, 1 skipped, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ