### PR TITLE
fix(import): validate account fields on import, fix poll-interval clamp and stale webhook hash

### DIFF
--- a/import_export.py
+++ b/import_export.py
@@ -30,6 +30,7 @@ import plans
 import settings
 from _version import __version__ as APP_VERSION
 from security import decrypt_secret, encrypt_secret, hash_secret
+from webhook import dump_headers
 
 FORMAT = "feedecho-export"
 VERSION = 1
@@ -67,6 +68,22 @@ _CREDENTIAL_COLS = {
     "microblog": {"token"},
     "matrix": {"access_token"},
     "discord": {"webhook_url"},
+}
+
+# Required columns per account section: NOT NULL in the schema (database.py)
+# with no usable code-level default, so a missing/blank/wrong-typed value
+# would otherwise bind straight into the INSERT and raise a bare
+# IntegrityError. (`username` for mastodon is NOT NULL-with-a-default and is
+# additionally back-filled from `name` in `_normalize_account`, so it's
+# deliberately not required here.)
+_REQUIRED_ACCOUNT_FIELDS = {
+    "mastodon": ("name", "instance", "access_token"),
+    "email": ("name", "email"),
+    "bluesky": ("name", "handle", "app_password"),
+    "microblog": ("name", "uid", "token"),
+    "matrix": ("name", "homeserver", "access_token", "room_id"),
+    "discord": ("name", "webhook_url"),
+    "webhook": ("name", "url"),
 }
 
 _FEED_COLS = ["name", "url", "feed_type", "poll_interval", "last_item_id", "paused", "read_enabled"]
@@ -252,10 +269,58 @@ def _normalize_account(section: str, account: dict) -> None:
             account[key] = value.strip()
     if section == "mastodon" and not account.get("username"):
         account["username"] = account.get("name") or ""
-    if section == "discord" and account.get("webhook_url"):
+    if section == "discord":
         # The natural key is the deterministic digest of the (plaintext) URL,
-        # which is stored encrypted at rest.
-        account["webhook_url_hash"] = hash_secret(str(account["webhook_url"]))
+        # which is stored encrypted at rest. Always recompute from whatever
+        # webhook_url is present -- never trust a webhook_url_hash carried in
+        # the import payload, forged or merely stale -- and clear it outright
+        # when there's no URL to hash from (webhook_url is required below,
+        # so that account is rejected rather than inserted with a hash that
+        # doesn't correspond to any URL).
+        webhook_url = account.get("webhook_url")
+        account["webhook_url_hash"] = (
+            hash_secret(str(webhook_url)) if webhook_url else ""
+        )
+    if section == "matrix" and not isinstance(account.get("base_url"), str):
+        # matrix_accounts.base_url is NOT NULL DEFAULT ''. SQL's DEFAULT only
+        # fires when a column is omitted from the INSERT entirely, not when
+        # an explicit NULL is bound to it (which is what `account.get(...)`
+        # returning None would otherwise do), so a missing/non-string value
+        # must be coerced here.
+        account["base_url"] = str(account.get("base_url") or "")
+    if section == "webhook":
+        # webhook_accounts.headers is NOT NULL DEFAULT '{}' and is stored as
+        # serialized JSON text, not a raw dict -- same DEFAULT-vs-explicit-
+        # NULL reasoning as base_url above, plus a type fixup so a document
+        # carrying a raw JSON object (rather than the string the export
+        # itself always produces) still serializes cleanly instead of
+        # binding a dict into a TEXT column.
+        headers = account.get("headers")
+        if isinstance(headers, dict):
+            account["headers"] = dump_headers(headers)
+        elif headers is None:
+            account["headers"] = "{}"
+
+
+def _validate_account(section: str, account: dict, record_id) -> None:
+    """Ensure an account's required NOT-NULL columns are present and typed.
+
+    Mirrors the feed-URL check in ``import_data``: raises ``ExportError``
+    identifying the offending account/field instead of letting a missing,
+    blank, or wrong-typed value (e.g. a dict where a string is expected)
+    reach the ``INSERT`` and surface as a bare IntegrityError -- the module
+    docstring's contract is that malformed input always raises
+    ``ExportError``, never a bare DB exception.
+    """
+    label = f"{section} account (id {record_id!r})"
+    for col in _REQUIRED_ACCOUNT_FIELDS[section]:
+        value = account.get(col)
+        if not isinstance(value, str) or not value:
+            raise ExportError(f"{label} is missing a required field: {col!r}.")
+    if section == "webhook":
+        headers = account.get("headers")
+        if not isinstance(headers, str):
+            raise ExportError(f"{label} has an invalid 'headers' value.")
 
 
 def _existing_account_id(db, uid: int, section: str, account: dict):
@@ -311,7 +376,11 @@ def _enforce_quotas(db, uid: int, new_feeds: int, new_destinations: int) -> None
 
 
 def _clamp_poll(db, uid: int, poll_interval) -> int:
-    poll = max(1, min(_try_int(poll_interval) or 15, 1440))
+    # `or 15` would treat an explicitly-parsed 0 as falsy and silently
+    # substitute the default instead of clamping it to the floor below, so
+    # the "missing/unparseable" fallback must check for None explicitly.
+    parsed = _try_int(poll_interval)
+    poll = max(1, min(parsed if parsed is not None else 15, 1440))
     if settings.MULTI:
         poll = plans.clamp_poll_interval(poll, _user_plan(db, uid))
     return poll
@@ -366,6 +435,7 @@ def import_data(db, uid: int, payload: dict) -> dict:
         for account in doc["accounts"][section]:
             old_id = _record_id(account, "Account")
             _normalize_account(section, account)
+            _validate_account(section, account, old_id)
             existing = _existing_account_id(db, uid, section, account)
             if existing:
                 account_maps[section][old_id] = existing["id"]

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -230,6 +230,126 @@ class TestRoundTrip:
             assert second["existing_accounts"] == 1
 
 
+class TestAccountValidation:
+    """Finding #6: malformed accounts must raise ExportError, never a bare
+    DB exception, and must never insert a partial/invalid row."""
+
+    @pytest.mark.parametrize("section,account,missing_field", [
+        ("mastodon", {"id": 1, "name": "M", "instance": "https://m.example"}, "access_token"),
+        ("bluesky", {"id": 1, "name": "B", "handle": "h.bsky.social"}, "app_password"),
+        ("matrix", {"id": 1, "name": "Mx", "homeserver": "https://matrix.example", "access_token": "t"}, "room_id"),
+        ("discord", {"id": 1, "name": "D"}, "webhook_url"),
+        ("microblog", {"id": 1, "name": "Mb", "uid": "u"}, "token"),
+        ("webhook", {"id": 1, "name": "W"}, "url"),
+    ])
+    def test_missing_required_field_raises_export_error(
+        self, temp_db, section, account, missing_field
+    ):
+        payload = _payload(accounts={section: [account]})
+        with get_db() as db:
+            with pytest.raises(import_export.ExportError) as exc_info:
+                import_export.import_data(db, 1, payload)
+        assert missing_field in str(exc_info.value)
+        with get_db() as db:
+            table = import_export.ACCOUNT_TABLES[section]
+            count = db.execute(f"SELECT COUNT(*) AS c FROM {table}").fetchone()["c"]
+        assert count == 0
+
+    def test_webhook_headers_dict_is_serialized_to_json_text(self, temp_db):
+        payload = _payload(accounts={
+            "webhook": [{
+                "id": 1, "name": "W", "url": "https://hooks.example/x",
+                "headers": {"X-Test": "1"},
+            }],
+        })
+        with get_db() as db:
+            summary = import_export.import_data(db, 1, payload)
+            assert summary["added_accounts"] == 1
+            row = db.execute("SELECT headers FROM webhook_accounts").fetchone()
+        assert isinstance(row["headers"], str)
+        assert json.loads(row["headers"]) == {"X-Test": "1"}
+
+    def test_webhook_headers_wrong_type_raises_export_error(self, temp_db):
+        payload = _payload(accounts={
+            "webhook": [{
+                "id": 1, "name": "W", "url": "https://hooks.example/x",
+                "headers": ["not", "a", "dict"],
+            }],
+        })
+        with get_db() as db:
+            with pytest.raises(import_export.ExportError):
+                import_export.import_data(db, 1, payload)
+
+    def test_discord_recomputes_hash_ignoring_stale_payload_value(self, temp_db):
+        """Finding #27: the hash in the payload must never be trusted --
+        it's always recomputed from webhook_url."""
+        payload = _payload(accounts={
+            "discord": [{
+                "id": 1, "name": "D",
+                "webhook_url": "https://discord.example/webhook/abc",
+                "webhook_url_hash": "not-the-real-hash",
+            }],
+        })
+        with get_db() as db:
+            summary = import_export.import_data(db, 1, payload)
+            assert summary["added_accounts"] == 1
+            row = db.execute("SELECT webhook_url_hash FROM discord_accounts").fetchone()
+        from security import hash_secret
+
+        assert row["webhook_url_hash"] == hash_secret(
+            "https://discord.example/webhook/abc"
+        )
+        assert row["webhook_url_hash"] != "not-the-real-hash"
+
+    def test_discord_empty_webhook_url_with_stale_hash_is_rejected(self, temp_db):
+        """An empty webhook_url with a leftover/forged webhook_url_hash must
+        not pass through as a usable dedup key -- validation rejects the
+        account outright rather than inserting a hash with no matching URL."""
+        payload = _payload(accounts={
+            "discord": [{
+                "id": 1, "name": "D", "webhook_url": "",
+                "webhook_url_hash": "stale-hash-from-a-different-url",
+            }],
+        })
+        with get_db() as db:
+            with pytest.raises(import_export.ExportError):
+                import_export.import_data(db, 1, payload)
+        with get_db() as db:
+            count = db.execute(
+                "SELECT COUNT(*) AS c FROM discord_accounts"
+            ).fetchone()["c"]
+        assert count == 0
+
+
+class TestPollIntervalClamp:
+    """Finding #26: an explicit poll_interval of 0 must clamp to the real
+    floor of 1, not be treated as falsy/missing and default to 15."""
+
+    def test_poll_interval_zero_clamps_to_one_not_default(self, temp_db):
+        payload = _payload(feeds=[
+            {"id": 1, "name": "F", "url": "https://a.example/rss", "poll_interval": 0},
+        ])
+        with get_db() as db:
+            import_export.import_data(db, 1, payload)
+            row = db.execute(
+                "SELECT poll_interval FROM feeds WHERE url = ?",
+                ("https://a.example/rss",),
+            ).fetchone()
+        assert row["poll_interval"] == 1
+
+    def test_poll_interval_missing_still_defaults_to_fifteen(self, temp_db):
+        payload = _payload(feeds=[
+            {"id": 1, "name": "F", "url": "https://a.example/rss"},
+        ])
+        with get_db() as db:
+            import_export.import_data(db, 1, payload)
+            row = db.execute(
+                "SELECT poll_interval FROM feeds WHERE url = ?",
+                ("https://a.example/rss",),
+            ).fetchone()
+        assert row["poll_interval"] == 15
+
+
 class TestQuota:
     def _setup_multi(self, monkeypatch, tmp_path, plan_limits):
         db_path = tmp_path / "multi.db"


### PR DESCRIPTION
## Summary
- Add `_validate_account` to `import_export.py`, validating every imported account's required NOT-NULL, no-usable-default columns (per `database.py`'s schema) before insert, raising `ExportError` with a message naming the account section/field instead of letting the DB insert fail with a bare `IntegrityError`. Also coerces `webhook_accounts.headers` from a raw dict to serialized JSON text, and `matrix_accounts.base_url` from a missing/non-string value to `""`, since SQL `DEFAULT` only applies when a column is omitted from the `INSERT`, not when an explicit `NULL` is bound.
- Fix `_clamp_poll` in `import_export.py`: `_try_int(poll_interval) or 15` treated an explicitly-parsed `0` as falsy and silently substituted `15` instead of clamping it to the intended floor of `1`. Now checks for `None` explicitly.
- Fix `_normalize_account` in `import_export.py`: Discord's `webhook_url_hash` is now always recomputed from `webhook_url` when present (never trusting the value carried in the import payload) and cleared when `webhook_url` is empty/missing, instead of letting a stale/forged hash pass through as the dedup key.

Reference: `docs/reviews/2026-09-09-bug-review.md` findings #6, #26, #27.

## Test plan
- Extended `tests/test_import_export.py` with:
  - `TestAccountValidation`: parametrized coverage of mastodon/bluesky/matrix/discord/microblog/webhook accounts missing a required field, asserting `ExportError` is raised (not a bare DB exception) and no row is inserted; plus tests for webhook `headers` dict-to-JSON coercion, rejecting a wrong-typed `headers` value, Discord hash recomputation ignoring a stale payload value, and rejecting a Discord account with an empty `webhook_url` but a stale `webhook_url_hash`.
  - `TestPollIntervalClamp`: `poll_interval: 0` imports as `1`, missing `poll_interval` still defaults to `15`.
- `FEEDECHO_MODE=single /tmp/feedecho-shared-venv/bin/python -m pytest -m "not pg and not multi" -q` → 1474 passed, 1 skipped, 118 deselected, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ