### PR TITLE
fix(scheduler): isolate per-item failures in digest/drip flush, fix email claim-guard ordering, add native idempotency keys

### DIFF
--- a/mastodon.py
+++ b/mastodon.py
@@ -1,8 +1,23 @@
 """Mastodon API client — post statuses via the Mastodon REST API."""
 
+import hashlib
 import httpx
 from typing import Optional
 from feed_parser import pinned_request, validate_outbound_url
+
+
+def idempotency_key(echo_id: int, item_id: str) -> str:
+    """A deterministic Idempotency-Key for one echo+item post.
+
+    Mastodon's POST /api/v1/statuses honors a client-supplied
+    Idempotency-Key header: submitting the same key twice within its
+    retention window returns the original status instead of creating a
+    duplicate. Deriving the key from the item ID (not random) means a
+    crash-then-reclaim retry of the same logical post reuses the same key
+    and is deduplicated server-side, mirroring Matrix's transaction_id.
+    """
+    digest = hashlib.sha256(str(item_id).encode("utf-8", "replace")).hexdigest()[:32]
+    return f"feedecho-{echo_id}-{digest}"
 
 
 def upload_media(
@@ -65,6 +80,7 @@ def post_status(
     sensitive: bool = False,
     spoiler_text: str = "",
     media_ids: list[str] | None = None,
+    idempotency_key: str | None = None,
 ) -> dict:
     """Post a status to a Mastodon instance.
 
@@ -76,6 +92,11 @@ def post_status(
         sensitive: Mark as sensitive content
         spoiler_text: Content warning text (shown above the post body)
         media_ids: List of media attachment IDs to attach
+        idempotency_key: Optional client-supplied key sent as the
+            Idempotency-Key header. Mastodon deduplicates a repeated POST
+            with the same key (within its retention window), returning the
+            original status instead of creating a second one — protects
+            against a crash-then-reclaim retry double-posting.
 
     Returns:
         Dict with response data including 'id' and 'url' on success.
@@ -87,6 +108,8 @@ def post_status(
     validate_outbound_url(instance)
     url = f"{instance}/api/v1/statuses"
     headers = {"Authorization": f"Bearer {access_token}"}
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
     data = {
         "status": content,
         "visibility": visibility,

--- a/scheduler.py
+++ b/scheduler.py
@@ -26,7 +26,11 @@ from feed_parser import (
     truncate,
 )
 from filters import is_filtered, match_reason
-from mastodon import post_status, upload_media
+from mastodon import (
+    idempotency_key as mastodon_idempotency_key,
+    post_status,
+    upload_media,
+)
 from bluesky import (
     BLUESKY_IMAGE_TYPES,
     MAX_BLOB_BYTES,
@@ -1312,6 +1316,10 @@ def _send_mastodon(
             sensitive=sensitive,
             spoiler_text=cw_text,
             media_ids=media_ids or None,
+            # Deterministic key from (echo_id, item_id): a crash-then-reclaim
+            # retry of this same logical post reuses the key, so Mastodon
+            # returns the original status instead of creating a duplicate.
+            idempotency_key=mastodon_idempotency_key(echo["id"], item["id"]),
         )
     except Exception:
         logger.exception("Echo %s: Mastodon post failed", echo["id"])
@@ -1353,11 +1361,6 @@ def _send_email_echo(
     if account is None:
         return fail_result
 
-    # Email is a one-way send too, so the same claim re-check applies: SMTP
-    # connect and delivery can outlast the lease.
-    if not _guard_claim(posted_id, claim_token, echo["id"], item["id"], "email"):
-        return False
-
     # Image embedding: mirroring the Mastodon path, attach_image fetches the
     # item's images (SSRF-validated, fallback-proxy aware) and embeds them
     # inline in the message. A failed fetch skips that image — the email
@@ -1386,6 +1389,15 @@ def _send_email_echo(
             images.append(
                 {"data": img_bytes, "content_type": img_type, "alt": entry["alt"]}
             )
+
+    # Re-validate claim ownership immediately before the send: email is a
+    # one-way send too, and the image-fetch loop above is slow network I/O
+    # that can outlast the lease, so the lease can lapse and another worker
+    # reclaim the row. Checking here (right before send, not before the
+    # fetch loop) matches the other senders and closes the window where a
+    # slow fetch let both workers send.
+    if not _guard_claim(posted_id, claim_token, echo["id"], item["id"], "email"):
+        return False
 
     try:
         send_email(
@@ -2550,68 +2562,87 @@ def _flush_drips() -> None:
         if echo_id in discarded:
             continue
 
-        if row["deleted_at"] or row["feed_deleted_at"]:
-            _discard_drip_backlog(echo_id, "Echo deleted; drip backlog discarded")
-            discarded.add(echo_id)
-            continue
-        if not row["enabled"]:
-            _discard_drip_backlog(echo_id, "Echo disabled; drip backlog discarded")
-            discarded.add(echo_id)
-            continue
-
-        # Serialize with process_echo so concurrent workers cannot both
-        # see an open window and exceed the hourly cap.
-        with _drip_lock(echo_id):
-            limit = _drip_limit(row)
-            if limit > 0 and _drip_rate(echo_id) >= limit:
-                continue
-            if limit <= 0 and released.get(echo_id, 0) >= DRIP_DOWNGRADE_BATCH:
-                # Limit removed: drain the stale backlog in batches
-                # instead of one burst.
-                continue
-
-            try:
-                item = json.loads(row["item_json"])
-            except (json.JSONDecodeError, TypeError):
-                logger.warning(
-                    "Drip queue: unreadable payload %s for echo %s; dropping",
-                    row["drip_id"],
-                    echo_id,
-                )
-                with get_db() as db:
-                    db.execute("DELETE FROM drip_items WHERE id = ?", (row["drip_id"],))
-                continue
-
-            claimed = _reclaim_queued(echo_id, row["item_id"])
-            if claimed is None:
-                # The posted row is no longer queued; remove the orphaned
-                # queue entry so it is not reconsidered forever.
-                with get_db() as db:
-                    db.execute("DELETE FROM drip_items WHERE id = ?", (row["drip_id"],))
-                continue
-
-            posted_id, claim_token = claimed
-            with get_db() as db:
-                db.execute("DELETE FROM drip_items WHERE id = ?", (row["drip_id"],))
-
-            logger.info(
-                "Echo %s: releasing dripped item %s (%d in window)",
+        try:
+            _flush_one_drip(row, discarded, released)
+        except Exception:
+            # Isolate one row's failure from the rest of the batch: an
+            # uncaught exception here (a transient DB error, an unexpected
+            # data shape) must not skip every other echo's pending drip
+            # item for the whole tick. Mirrors _flush_queue's per-row
+            # isolation.
+            logger.exception(
+                "Drip flush: unhandled error for echo %s item %s",
                 echo_id,
                 row["item_id"],
-                _drip_rate(echo_id),
             )
-            _render_and_dispatch(dict(row), item, row["feed_name"] or "", posted_id, claim_token)
+            continue
 
-            if _row_state(echo_id, row["item_id"]) == "failed":
-                _requeue_drip_failure(
-                    echo_id,
-                    row["item_id"],
-                    row["item_json"],
-                    row["attempts"],
-                    posted_id,
-                )
-            else:
-                released[echo_id] = released.get(echo_id, 0) + 1
+
+def _flush_one_drip(row, discarded: set[int], released: dict[int, int]) -> None:
+    echo_id = row["id"]
+
+    if row["deleted_at"] or row["feed_deleted_at"]:
+        _discard_drip_backlog(echo_id, "Echo deleted; drip backlog discarded")
+        discarded.add(echo_id)
+        return
+    if not row["enabled"]:
+        _discard_drip_backlog(echo_id, "Echo disabled; drip backlog discarded")
+        discarded.add(echo_id)
+        return
+
+    # Serialize with process_echo so concurrent workers cannot both
+    # see an open window and exceed the hourly cap.
+    with _drip_lock(echo_id):
+        limit = _drip_limit(row)
+        if limit > 0 and _drip_rate(echo_id) >= limit:
+            return
+        if limit <= 0 and released.get(echo_id, 0) >= DRIP_DOWNGRADE_BATCH:
+            # Limit removed: drain the stale backlog in batches
+            # instead of one burst.
+            return
+
+        try:
+            item = json.loads(row["item_json"])
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Drip queue: unreadable payload %s for echo %s; dropping",
+                row["drip_id"],
+                echo_id,
+            )
+            with get_db() as db:
+                db.execute("DELETE FROM drip_items WHERE id = ?", (row["drip_id"],))
+            return
+
+        claimed = _reclaim_queued(echo_id, row["item_id"])
+        if claimed is None:
+            # The posted row is no longer queued; remove the orphaned
+            # queue entry so it is not reconsidered forever.
+            with get_db() as db:
+                db.execute("DELETE FROM drip_items WHERE id = ?", (row["drip_id"],))
+            return
+
+        posted_id, claim_token = claimed
+        with get_db() as db:
+            db.execute("DELETE FROM drip_items WHERE id = ?", (row["drip_id"],))
+
+        logger.info(
+            "Echo %s: releasing dripped item %s (%d in window)",
+            echo_id,
+            row["item_id"],
+            _drip_rate(echo_id),
+        )
+        _render_and_dispatch(dict(row), item, row["feed_name"] or "", posted_id, claim_token)
+
+        if _row_state(echo_id, row["item_id"]) == "failed":
+            _requeue_drip_failure(
+                echo_id,
+                row["item_id"],
+                row["item_json"],
+                row["attempts"],
+                posted_id,
+            )
+        else:
+            released[echo_id] = released.get(echo_id, 0) + 1
 
 
 def _discard_orphaned_digest_items() -> None:
@@ -2714,143 +2745,155 @@ def _flush_digests() -> None:
 
     for echo_row in pending_echoes:
         echo_id = echo_row["echo_id"]
-        with get_db() as db:
-            items = db.execute(
-                "SELECT * FROM digest_items WHERE echo_id = ? ORDER BY created_at ASC",
-                (echo_id,),
-            ).fetchall()
-
-        if not items:
-            continue
-
-        # Build digest body incrementally so overflow can be detected
-        # per-item: everything that fits goes out now, the rest stays
-        # queued for the next flush. Silently truncating here reported
-        # dropped content as delivered.
-        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        subject = f"FeedEcho Digest — {echo_row['feed_name']} — {date_str}"
-
-        header = [f"FeedEcho Digest for {echo_row['feed_name']}", f"Date: {date_str}", ""]
-
-        body_parts = list(header)
-        used = sum(len(p) + 1 for p in body_parts)
-        sent_items, held_items = [], []
-        for i, item in enumerate(items, 1):
-            title = item["item_title"] or item["item_url"] or f"Item {i}"
-            lines = (
-                f"{i}. {title}",
-                f"   {item['rendered_content']}",
-                "",
-            )
-            added = sum(len(ln) + 1 for ln in lines)
-            if used + added > DIGEST_MAX_CHARS - DIGEST_NOTICE_RESERVE:
-                held_items.append(item)
-                continue
-            body_parts.extend(lines)
-            used += added
-            sent_items.append(item)
-
-        if held_items and not sent_items:
-            # A single item larger than the whole cap: normally send it
-            # truncated so one giant item cannot wedge the queue forever.
-            # Degenerate case (a pathological title/URL that leaves no room
-            # for any content): keep everything held instead of sending a
-            # content-less title.
-            first = held_items.pop(0)
-            body_parts.append(f"1. {first['item_title'] or first['item_url'] or 'Item 1'}")
-            budget = DIGEST_MAX_CHARS - DIGEST_NOTICE_RESERVE - used - len(body_parts[-1]) - 8
-            if budget <= 0:
-                held_items.insert(0, first)
-            else:
-                body_parts.append(f"   {first['rendered_content'][:budget]}…")
-                sent_items.append(first)
-
-        if not sent_items:
-            # Nothing fit this round (pathological content only): leave the
-            # queue untouched rather than send an empty digest or drop the
-            # item. Logged loudly so a wedged queue is discoverable.
-            logger.warning(
-                "Digest for echo %s held: an item exceeds the %d char cap",
-                echo_id,
-                DIGEST_MAX_CHARS,
-            )
-            continue
-
-        body = "\n".join(body_parts)
-        if held_items:
-            body += (
-                f"\n\n[{len(held_items)} newer item{'s' if len(held_items) != 1 else ''}"
-                " held for the next digest to stay under the size cap.]"
-            )
-
         try:
-            send_email(
-                to_email=echo_row["to_email"],
-                subject=subject,
-                body=body,
-                user_id=echo_row["user_id"],
-            )
-        except Exception as exc:
-            logger.exception(
-                "Digest flush failed for echo %s (%s, %d items)",
-                echo_id,
-                echo_row["feed_name"],
-                len(items),
-            )
-            # Surface digest send failures to the user: mark the ATTEMPTED
-            # rows (the ones in the body) 'failed' — without a retry time,
-            # so the retry sweep never grabs them; only flush_digests owns
-            # digest delivery — so the failure counter in
-            # notify.record_failure can reach its threshold and alert on a
-            # permanently broken SMTP config. Held items were never
-            # attempted this round and stay 'queued'.
-            with get_db() as db:
-                for item in sent_items:
-                    db.execute(
-                        """UPDATE posted_items
-                              SET status = 'failed',
-                                  error_message = ?,
-                                  next_retry_at = NULL,
-                                  attempt_count = attempt_count + 1
-                            WHERE echo_id = ? AND item_id = ?
-                              AND status IN ('queued', 'failed')""",
-                        (f"Digest send failed: {exc}", echo_id, item["item_id"]),
-                    )
-            record_failure(echo_id)
-            # Leave digest_items intact — the next successful flush sends them.
+            _flush_one_digest(echo_id, echo_row)
+        except Exception:
+            # Isolate one echo's failure from the rest of the batch: an
+            # uncaught exception here (a transient DB error, an unexpected
+            # data shape) must not skip every other tenant's pending digest
+            # for the whole tick. Mirrors _flush_queue's per-row isolation.
+            logger.exception("Digest flush: unhandled error for echo %s", echo_id)
             continue
 
-        # Success — delete only the sent items and update posted_items to
-        # 'success'; held items stay queued for the next flush.
-        sent_item_ids = [item["item_id"] for item in sent_items]
-        with get_db() as db:
-            for item in sent_items:
-                # Update posted_items to 'success'. 'failed' is included:
-                # a prior flush may have marked the row failed on a send
-                # error; a successful send now must still finalize it,
-                # else the queue row below is deleted with the posted_item
-                # stuck on 'failed'.
-                db.execute(
-                    """UPDATE posted_items SET status = 'success', posted_at = ?
-                       WHERE echo_id = ? AND item_id = ?
-                         AND status IN ('queued', 'failed')""",
-                    (_now(), echo_id, item["item_id"]),
-                )
-            # Delete only the sent items, not any that may have arrived concurrently
-            placeholders = ",".join("?" for _ in sent_item_ids)
-            db.execute(
-                f"DELETE FROM digest_items WHERE echo_id = ? AND item_id IN ({placeholders})",
-                (echo_id, *sent_item_ids),
-            )
 
-        record_success(echo_id)
-        logger.info(
-            "Digest flushed for echo %s (%s): %d items sent, %d held",
+def _flush_one_digest(echo_id: int, echo_row) -> None:
+    with get_db() as db:
+        items = db.execute(
+            "SELECT * FROM digest_items WHERE echo_id = ? ORDER BY created_at ASC",
+            (echo_id,),
+        ).fetchall()
+
+    if not items:
+        return
+
+    # Build digest body incrementally so overflow can be detected
+    # per-item: everything that fits goes out now, the rest stays
+    # queued for the next flush. Silently truncating here reported
+    # dropped content as delivered.
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    subject = f"FeedEcho Digest — {echo_row['feed_name']} — {date_str}"
+
+    header = [f"FeedEcho Digest for {echo_row['feed_name']}", f"Date: {date_str}", ""]
+
+    body_parts = list(header)
+    used = sum(len(p) + 1 for p in body_parts)
+    sent_items, held_items = [], []
+    for i, item in enumerate(items, 1):
+        title = item["item_title"] or item["item_url"] or f"Item {i}"
+        lines = (
+            f"{i}. {title}",
+            f"   {item['rendered_content']}",
+            "",
+        )
+        added = sum(len(ln) + 1 for ln in lines)
+        if used + added > DIGEST_MAX_CHARS - DIGEST_NOTICE_RESERVE:
+            held_items.append(item)
+            continue
+        body_parts.extend(lines)
+        used += added
+        sent_items.append(item)
+
+    if held_items and not sent_items:
+        # A single item larger than the whole cap: normally send it
+        # truncated so one giant item cannot wedge the queue forever.
+        # Degenerate case (a pathological title/URL that leaves no room
+        # for any content): keep everything held instead of sending a
+        # content-less title.
+        first = held_items.pop(0)
+        body_parts.append(f"1. {first['item_title'] or first['item_url'] or 'Item 1'}")
+        budget = DIGEST_MAX_CHARS - DIGEST_NOTICE_RESERVE - used - len(body_parts[-1]) - 8
+        if budget <= 0:
+            held_items.insert(0, first)
+        else:
+            body_parts.append(f"   {first['rendered_content'][:budget]}…")
+            sent_items.append(first)
+
+    if not sent_items:
+        # Nothing fit this round (pathological content only): leave the
+        # queue untouched rather than send an empty digest or drop the
+        # item. Logged loudly so a wedged queue is discoverable.
+        logger.warning(
+            "Digest for echo %s held: an item exceeds the %d char cap",
+            echo_id,
+            DIGEST_MAX_CHARS,
+        )
+        return
+
+    body = "\n".join(body_parts)
+    if held_items:
+        body += (
+            f"\n\n[{len(held_items)} newer item{'s' if len(held_items) != 1 else ''}"
+            " held for the next digest to stay under the size cap.]"
+        )
+
+    try:
+        send_email(
+            to_email=echo_row["to_email"],
+            subject=subject,
+            body=body,
+            user_id=echo_row["user_id"],
+        )
+    except Exception as exc:
+        logger.exception(
+            "Digest flush failed for echo %s (%s, %d items)",
             echo_id,
             echo_row["feed_name"],
-            len(sent_items),
-            len(held_items),
+            len(items),
         )
+        # Surface digest send failures to the user: mark the ATTEMPTED
+        # rows (the ones in the body) 'failed' — without a retry time,
+        # so the retry sweep never grabs them; only flush_digests owns
+        # digest delivery — so the failure counter in
+        # notify.record_failure can reach its threshold and alert on a
+        # permanently broken SMTP config. Held items were never
+        # attempted this round and stay 'queued'.
+        with get_db() as db:
+            for item in sent_items:
+                db.execute(
+                    """UPDATE posted_items
+                          SET status = 'failed',
+                              error_message = ?,
+                              next_retry_at = NULL,
+                              attempt_count = attempt_count + 1
+                        WHERE echo_id = ? AND item_id = ?
+                          AND status IN ('queued', 'failed')""",
+                    (f"Digest send failed: {exc}", echo_id, item["item_id"]),
+                )
+        record_failure(echo_id)
+        # Leave digest_items intact — the next successful flush sends them.
+        return
+
+    # Success — delete only the sent items and update posted_items to
+    # 'success'; held items stay queued for the next flush.
+    sent_item_ids = [item["item_id"] for item in sent_items]
+    with get_db() as db:
+        for item in sent_items:
+            # Update posted_items to 'success'. 'failed' is included:
+            # a prior flush may have marked the row failed on a send
+            # error; a successful send now must still finalize it,
+            # else the queue row below is deleted with the posted_item
+            # stuck on 'failed'.
+            db.execute(
+                """UPDATE posted_items SET status = 'success', posted_at = ?
+                   WHERE echo_id = ? AND item_id = ?
+                     AND status IN ('queued', 'failed')""",
+                (_now(), echo_id, item["item_id"]),
+            )
+        # Delete only the sent items, not any that may have arrived concurrently
+        placeholders = ",".join("?" for _ in sent_item_ids)
+        db.execute(
+            f"DELETE FROM digest_items WHERE echo_id = ? AND item_id IN ({placeholders})",
+            (echo_id, *sent_item_ids),
+        )
+
+    record_success(echo_id)
+    logger.info(
+        "Digest flushed for echo %s (%s): %d items sent, %d held",
+        echo_id,
+        echo_row["feed_name"],
+        len(sent_items),
+        len(held_items),
+    )
 
 
 def check_all_feeds() -> None:

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -398,6 +398,81 @@ class TestDigestFlush:
         assert "1. First" in body
         assert "2. Second" in body
 
+    def test_flush_isolates_failing_echo_from_others(self, db_tmp, monkeypatch):
+        """One echo raising mid-processing must not skip the rest of the batch.
+
+        Regression test for a missing per-row try/except in _flush_digests:
+        previously an uncaught exception anywhere in an echo's processing
+        body (not just the narrow send_email guard) propagated out of
+        _flush_digests entirely, leaving every echo scheduled after the
+        offending one in iteration order unflushed for that whole tick.
+        """
+        import scheduler
+
+        sent_emails = []
+        monkeypatch.setattr(
+            scheduler, "send_email", lambda **kw: sent_emails.append(kw) or {"success": True}
+        )
+
+        # Echo 1: will blow up during finalize (record_success), a step that
+        # was never wrapped in the old narrow try/except.
+        echo1 = _setup_email_echo(db_tmp)
+
+        # Echo 2: a second, unrelated echo that must still be flushed.
+        with db_tmp.get_db() as db:
+            db.execute(
+                "INSERT INTO email_accounts (name, email) VALUES (?, ?)",
+                ("User 2", "user2@example.com"),
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url) VALUES (?, ?)",
+                ("f2", "https://example.com/feed2"),
+            )
+            db.execute(
+                """INSERT INTO echoes (feed_id, destination_type, destination_id, template,
+                                       visibility, filter_keywords, filter_mode,
+                                       content_warning, attach_image, delivery_mode, enabled)
+                   VALUES (2, 'email', 2, '{{ title }}', 'public', '', 'exclude', '', 0, 'digest', 1)""",
+            )
+            echo2 = db.execute("SELECT * FROM echoes WHERE id = 2").fetchone()
+
+        scheduler.process_echo(echo1, _item(id="a1", title="From Feed 1"))
+        scheduler.process_echo(echo2, _item(id="b1", title="From Feed 2"))
+
+        orig_record_success = scheduler.record_success
+
+        def flaky_record_success(echo_id):
+            if echo_id == 1:
+                raise RuntimeError("transient DB error")
+            return orig_record_success(echo_id)
+
+        monkeypatch.setattr(scheduler, "record_success", flaky_record_success)
+
+        scheduler.flush_digests()
+
+        # Echo 2's digest still went out despite echo 1 (processed first)
+        # raising during its finalize step.
+        bodies = [e["body"] for e in sent_emails]
+        assert any("From Feed 2" in b for b in bodies)
+
+        with db_tmp.get_db() as db:
+            echo2_items = db.execute("SELECT * FROM digest_items WHERE echo_id = 2").fetchall()
+        assert echo2_items == []
+
+        # Echo 1's email still went out and its posted_items/digest_items
+        # finalize writes (which happen before record_success) still landed;
+        # only the record_success call itself failed, and that failure was
+        # contained to echo 1's iteration instead of aborting the whole
+        # flush before echo 2 was ever reached.
+        assert any("From Feed 1" in b for b in bodies)
+        with db_tmp.get_db() as db:
+            echo1_items = db.execute("SELECT * FROM digest_items WHERE echo_id = 1").fetchall()
+            echo1_status = db.execute(
+                "SELECT status FROM posted_items WHERE echo_id = 1 AND item_id = 'a1'"
+            ).fetchone()["status"]
+        assert echo1_items == []
+        assert echo1_status == "success"
+
     def test_flush_after_failed_then_succeeded(self, db_tmp, monkeypatch):
         """If first flush fails, items should remain and succeed on second flush."""
         import scheduler

--- a/tests/test_drip.py
+++ b/tests/test_drip.py
@@ -363,6 +363,62 @@ class TestFlushDrips:
         assert _state(database, 1, "item-1") == "success"
         assert _drip_row_count(database, 1) == 0
 
+    def test_flush_isolates_failing_echo_from_others(self, env, monkeypatch):
+        """One echo raising mid-processing must not skip the rest of the batch.
+
+        Regression test for a missing per-row try/except in _flush_drips:
+        previously an uncaught exception anywhere in a row's processing body
+        (not just the narrow json.loads/post-status guards) propagated out of
+        _flush_drips entirely, leaving every echo scheduled after the
+        offending row in iteration order unprocessed for that whole tick.
+        """
+        database, scheduler, _ = env
+        echo1 = _seed(env, drip_limit=2)
+
+        with database.get_db() as db:
+            db.execute(
+                "INSERT INTO accounts (name, username, instance, access_token)"
+                " VALUES ('main2', 'user2', 'https://mastodon.social', 'tok2')"
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url) VALUES ('f2', 'https://example.com/feed2')"
+            )
+            db.execute(
+                """INSERT INTO echoes (feed_id, destination_type, destination_id, template,
+                                       visibility, filter_keywords, filter_mode, enabled,
+                                       delivery_mode, drip_limit, content_warning, attach_image)
+                   VALUES (2, 'mastodon', 2, '{{ title }}', 'public', '', 'exclude', 1,
+                           'instant', 2, '', 0)"""
+            )
+
+        _queue_item(database, 1, "item-1", _item(id="item-1"))
+        _queue_item(database, 2, "item-2", _item(id="item-2"))
+
+        orig_drip_rate = scheduler._drip_rate
+
+        def flaky_drip_rate(echo_id):
+            if echo_id == 1:
+                raise RuntimeError("transient DB error")
+            return orig_drip_rate(echo_id)
+
+        monkeypatch.setattr(scheduler, "_drip_rate", flaky_drip_rate)
+
+        posted = []
+        monkeypatch.setattr(scheduler, "post_status", lambda **kw: posted.append(kw) or {"id": "x"})
+
+        scheduler.flush_drips()
+
+        # Echo 2's item is still delivered, even though echo 1 (processed
+        # first) raised.
+        assert len(posted) == 1
+        assert _state(database, 2, "item-2") == "success"
+        assert _drip_row_count(database, 2) == 0
+
+        # Echo 1's item is left untouched (not silently dropped) so a later
+        # flush retries it once the transient error clears.
+        assert _state(database, 1, "item-1") == "queued"
+        assert _drip_row_count(database, 1) == 1
+
     def test_release_gives_up_after_attempt_cap(self, env, monkeypatch):
         database, scheduler, _ = env
         _seed(env, drip_limit=5)

--- a/tests/test_email_images.py
+++ b/tests/test_email_images.py
@@ -188,6 +188,85 @@ class TestEmailEchoImages:
         assert len(sent) == 1
         assert len(sent[0]["images"]) == 1
 
+class TestEmailClaimGuardOrdering:
+    """_send_email_echo must re-validate its claim AFTER the slow image-fetch
+    loop, immediately before send_email — not before it.
+
+    All other destination senders (_send_mastodon, _send_bluesky, etc.) call
+    _guard_claim right before the irreversible network send, specifically
+    because the image-fetch/alt-text pipeline is what can let the claim go
+    stale (reclaimed by another worker once PENDING_RECLAIM_SECONDS has
+    elapsed). _send_email_echo used to check the claim BEFORE the image-fetch
+    loop, leaving no re-check for a reclaim that happens during that fetch —
+    which could send a duplicate email.
+    """
+
+    def test_stale_claim_during_image_fetch_aborts_the_send(self, db_tmp, monkeypatch):
+        """A reclaim that happens mid-fetch must still be caught before send."""
+        import scheduler
+
+        echo = _setup_email_echo(db_tmp, {"attach_image": 1})
+
+        with db_tmp.get_db() as db:
+            db.execute(
+                "INSERT INTO posted_items (id, echo_id, item_id, status, claim_token)"
+                " VALUES (1, 1, 'item-1', 'pending', 'our-token')"
+            )
+
+        def flaky_fetch_image(url):
+            # Simulate another worker reclaiming this row while this worker
+            # is still doing the slow image fetch: the lease lapses mid-I/O.
+            with db_tmp.get_db() as db:
+                db.execute(
+                    "UPDATE posted_items SET claim_token = 'someone-elses-token'"
+                    " WHERE id = 1"
+                )
+            return (b"fake-image-bytes", "image/jpeg")
+
+        monkeypatch.setattr(scheduler, "fetch_image", flaky_fetch_image)
+
+        sent = []
+        monkeypatch.setattr(
+            scheduler, "send_email", lambda **kw: sent.append(kw) or {"success": True}
+        )
+
+        item = _item(image_url="https://example.com/photo.jpg", image_alt="A photo")
+        result = scheduler._send_email_echo(echo, item, "content", 1, 1, "our-token")
+
+        # The point of moving the guard: the lost claim is caught right
+        # before send, so no email goes out at all. (With the guard checked
+        # before the fetch instead, the fetch happens, the guard has
+        # already passed, and send_email fires anyway — a duplicate.)
+        assert result is False
+        assert sent == [], "email was sent despite having lost the claim mid-fetch"
+
+    def test_fresh_claim_survives_image_fetch_and_sends(self, db_tmp, monkeypatch):
+        """Sanity check: an uncontested claim still sends normally."""
+        import scheduler
+
+        echo = _setup_email_echo(db_tmp, {"attach_image": 1})
+
+        with db_tmp.get_db() as db:
+            db.execute(
+                "INSERT INTO posted_items (id, echo_id, item_id, status, claim_token)"
+                " VALUES (1, 1, 'item-1', 'pending', 'our-token')"
+            )
+
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+        sent = []
+        monkeypatch.setattr(
+            scheduler, "send_email", lambda **kw: sent.append(kw) or {"success": True}
+        )
+
+        item = _item(image_url="https://example.com/photo.jpg", image_alt="A photo")
+        result = scheduler._send_email_echo(echo, item, "content", 1, 1, "our-token")
+
+        assert result is True
+        assert len(sent) == 1
+
+
 # ── MIME construction in email_sender ────────────────────────────────────────
 
 class _FakeSMTP:

--- a/tests/test_mastodon_post_url.py
+++ b/tests/test_mastodon_post_url.py
@@ -206,3 +206,108 @@ class TestHistoryRendersPostLink:
             )
             page = c.get("/").text
         assert 'href="https://mastodon.social/@user/111"' in page
+
+# ── Idempotency key (crash-then-reclaim duplicate protection) ────────────────
+
+class _FakeResponse:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body if body is not None else {"id": "1", "url": "https://mastodon.social/@user/1"}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._body
+
+class TestMastodonIdempotencyKey:
+    """Matrix derives a deterministic transaction ID from (echo_id, item_id)
+    so a homeserver-side retry after a crash-then-reclaim is deduplicated.
+    Mastodon's POST /api/v1/statuses supports the same thing via a
+    client-supplied Idempotency-Key header — these tests pin that a
+    deterministic key is sent and threaded through from the scheduler.
+    """
+
+    def test_idempotency_key_is_deterministic_for_same_echo_and_item(self):
+        import mastodon
+
+        key1 = mastodon.idempotency_key(42, "item-1")
+        key2 = mastodon.idempotency_key(42, "item-1")
+        assert key1 == key2
+
+    def test_idempotency_key_differs_across_items_and_echoes(self):
+        import mastodon
+
+        base = mastodon.idempotency_key(42, "item-1")
+        assert mastodon.idempotency_key(42, "item-2") != base
+        assert mastodon.idempotency_key(7, "item-1") != base
+
+    def test_post_status_sends_idempotency_key_header(self, monkeypatch):
+        import mastodon
+
+        captured = {}
+
+        def fake_pinned_request(method, url, **kw):
+            captured.update(kw)
+            return _FakeResponse()
+
+        monkeypatch.setattr(mastodon, "pinned_request", fake_pinned_request)
+
+        key = mastodon.idempotency_key(1, "item-1")
+        mastodon.post_status(
+            instance="https://mastodon.social",
+            access_token="tok",
+            content="hello",
+            idempotency_key=key,
+        )
+
+        assert captured["headers"]["Idempotency-Key"] == key
+
+    def test_post_status_omits_header_when_no_key_given(self, monkeypatch):
+        import mastodon
+
+        captured = {}
+
+        def fake_pinned_request(method, url, **kw):
+            captured.update(kw)
+            return _FakeResponse()
+
+        monkeypatch.setattr(mastodon, "pinned_request", fake_pinned_request)
+
+        mastodon.post_status(
+            instance="https://mastodon.social",
+            access_token="tok",
+            content="hello",
+        )
+
+        assert "Idempotency-Key" not in captured["headers"]
+
+    def test_send_mastodon_passes_a_deterministic_key_across_calls(
+        self, db_tmp, monkeypatch, setup_echo
+    ):
+        """Two dispatch attempts for the same echo+item (e.g. a crash-then-
+        reclaim retry) must send the same Idempotency-Key both times, so
+        Mastodon's server-side dedup can recognize the retry."""
+        import scheduler
+
+        keys_seen = []
+
+        def fake_post_status(**kw):
+            keys_seen.append(kw.get("idempotency_key"))
+            return {"id": "1", "url": "https://mastodon.social/@user/1"}
+
+        monkeypatch.setattr(scheduler, "post_status", fake_post_status)
+
+        echo = setup_echo(attach_image=0)
+        item = _item()
+        assert scheduler.process_echo(echo, item) is True
+
+        # Re-claim and dispatch the same item again (simulating a retry).
+        with get_db() as db:
+            db.execute("DELETE FROM posted_items WHERE echo_id = 1 AND item_id = ?", (item["id"],))
+        assert scheduler.process_echo(echo, item) is True
+
+        assert len(keys_seen) == 2
+        assert keys_seen[0] == keys_seen[1]
+        assert keys_seen[0] is not None


### PR DESCRIPTION
## Summary
- `_flush_digests`/`_flush_drips` only wrapped a narrow inner call in try/except; an uncaught exception anywhere else in one echo's/row's processing propagated out of the whole function and silently skipped every other tenant's pending digest/drip item for the tick. Extracted `_flush_one_digest`/`_flush_one_drip` helpers and wrapped each row's processing in its own try/except, mirroring `_flush_queue`'s existing per-row isolation.
- `_send_email_echo` re-validated its claim lease *before* the slow image-fetch loop instead of after, unlike every other destination sender. A slow fetch could outlast the reclaim window (`PENDING_RECLAIM_SECONDS`) and let a second worker send a duplicate email. Moved the `_guard_claim` call to immediately before `send_email`, after image embedding — matching the other senders.
- Added a deterministic `Idempotency-Key` header to Mastodon's `POST /api/v1/statuses` (derived from `echo_id`+`item_id`), so a crash-then-reclaim retry of the same logical post is deduplicated server-side by Mastodon itself, mirroring Matrix's existing `transaction_id` approach.
- Bluesky's equivalent (an explicit deterministic `rkey` on `createRecord`) was investigated but **not implemented** — it carries more risk to normal posting than could be verified without live testing against the AT Protocol. Documented here as a residual gap rather than shipped half-verified.
- Discord, webhook, and micro.blog have no native idempotency mechanism and are left as-is — no fake header was added. This residual duplicate-delivery risk on those three destinations (plus Bluesky) after a crash-then-reclaim would need a larger architectural change (e.g. persisting a "send in flight" state before the network call, checked on reclaim) to close properly.

Fixes `docs/reviews/2026-09-09-bug-review.md` findings #7, #15, #16.

## Test plan
- `FEEDECHO_MODE=single pytest -m "not pg and not multi" -q` → 1471 passed, 1 skipped, no regressions.
- Added/extended tests in `tests/test_digest.py`, `tests/test_drip.py`, `tests/test_email_images.py`, `tests/test_mastodon_post_url.py` covering: one bad echo in a digest/drip batch no longer blocks delivery to other echoes; the email claim-guard now runs after image fetch; Mastodon sends a deterministic `Idempotency-Key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ