### PR TITLE
fix(app): correct dashboard failure count, saved-search unread accuracy, and cache invalidation gaps

### DIFF
--- a/app.py
+++ b/app.py
@@ -1304,7 +1304,7 @@ async def dashboard(request: Request):
             ).fetchone()["n"],
             "failed_posts": db.execute(
                 "SELECT COUNT(*) AS n FROM posted_items pi JOIN echoes e ON pi.echo_id = e.id"
-                " WHERE pi.status = 'failed' AND e.user_id = ?",
+                " WHERE pi.status IN ('failed', 'gave_up') AND e.user_id = ?",
                 (uid,),
             ).fetchone()["n"],
         }
@@ -2806,11 +2806,14 @@ async def reader_page(
 
                 for s in saved_searches:
                     s_filters, s_terms = _parse_reader_query(s["query"])
-                    # Default to unread counts, but is:read or is:starred override the default
-                    has_read_state = any(op == "is" and val in ("read", "starred") for op, val in s_filters)
+                    # Mirror the /reader route's own read-state handling for a
+                    # non-empty query (see the "unread/starred view filter is
+                    # skipped" comment above): no implicit unread-only default,
+                    # only an explicit is:read/is:unread/is:starred filters the
+                    # count. Saved-search queries are never empty (enforced at
+                    # creation), so this always matches what opening the saved
+                    # search actually shows.
                     s_where = ["f.user_id = ?", "f.read_enabled = 1", "f.deleted_at IS NULL"]
-                    if not has_read_state:
-                        s_where.append("i.is_read = 0")
                     s_params: list = [uid]
                     s_text_scope = None
                     for op, val in s_filters:
@@ -2818,7 +2821,7 @@ async def reader_page(
                             if val == "starred":
                                 s_where.append("i.starred = 1")
                             elif val == "unread":
-                                pass
+                                s_where.append("i.is_read = 0")
                             elif val == "read":
                                 s_where.append("i.is_read = 1")
                         elif op == "feed":
@@ -4252,6 +4255,8 @@ def rename_folder(request: Request, folder_id: int, name: str = Form(...)):
             "UPDATE folders SET name = ? WHERE id = ? AND user_id = ?",
             (name, folder_id, uid),
         )
+    # Saved searches can filter on folder:<name>, so a rename changes them
+    _saved_search_counts_cache.invalidate(uid)
     return RedirectResponse(url="/feeds", status_code=303)
 
 
@@ -4274,6 +4279,8 @@ def delete_folder(request: Request, folder_id: int):
             "DELETE FROM folders WHERE id = ? AND user_id = ?",
             (folder_id, uid),
         )
+    # Saved searches can filter on folder:<name>, so deleting one changes them
+    _saved_search_counts_cache.invalidate(uid)
     return RedirectResponse(url="/feeds", status_code=303)
 
 
@@ -4299,6 +4306,8 @@ def set_feed_folder(request: Request, feed_id: int, folder_id: str = Form("")):
             "UPDATE feeds SET folder_id = ? WHERE id = ? AND user_id = ?",
             (target_folder_id, feed_id, uid),
         )
+    # Saved searches can filter on folder:<name>, so moving a feed changes them
+    _saved_search_counts_cache.invalidate(uid)
     return {"success": True, "folder_id": target_folder_id}
 
 
@@ -4665,6 +4674,9 @@ async def edit_feed(
                 "WHERE id = ? AND deleted_at IS NULL AND user_id = ?",
                 (name, url, poll_interval, mute_keywords, final_folder_id, feed_id, uid),
             )
+    # Saved-search counts apply mute keywords and folder scoping, so editing
+    # either changes them.
+    _saved_search_counts_cache.invalidate(uid)
     return RedirectResponse(url="/feeds", status_code=303)
 
 

--- a/app.py
+++ b/app.py
@@ -2458,13 +2458,13 @@ _CURSOR_RE = re.compile(r"^[0-9 :.\-]*\|\d+$")
 
 
 class _SavedSearchCountsCache:
-    """Per-user, 60s TTL cache of saved-search unread counts.
+    """Per-user, 60s TTL cache of saved-search item counts.
 
     Invalidation is keyed by max_item_id (see .get()) rather than pure
     time, so a stale entry never outlives the item that would change it by
     more than the TTL. Every route that mutates saved searches, feeds, or
     read-state must call .invalidate(uid) — wrapped in a class (instead of
-    the previous bare module-level dict) so every one of those 9 call
+    the previous bare module-level dict) so every one of those call
     sites reads as an obvious, greppable method name rather than a
     dict.pop() that looks like ordinary housekeeping and is easy to miss
     in a diff. Design-patterns audit finding 2.8.
@@ -2789,7 +2789,7 @@ async def reader_page(
         ).fetchone()
         max_item_id = max_row["m"] if max_row else 0
 
-        # Compute unread counts for saved searches (with in-process 60s cache keyed by (uid, max_item_id))
+        # Compute counts for saved searches (with in-process 60s cache keyed by (uid, max_item_id))
         saved_search_counts: dict[int, int] = {}
         if saved_searches:
             now_time = time.time()
@@ -4602,6 +4602,8 @@ def import_opml(
                 break
         walk(body_elem if body_elem is not None else root, None, 1)
 
+    # Importing feeds and folders can alter saved-search matches
+    _saved_search_counts_cache.invalidate(uid)
     return RedirectResponse(
         url=f"/feeds?imported={imported}&duplicate={duplicate}&invalid={invalid}&capped={capped}",
         status_code=303,

--- a/tests/test_dashboard_stats.py
+++ b/tests/test_dashboard_stats.py
@@ -1,0 +1,89 @@
+"""Dashboard "Failed" stat (GET /) must count both 'failed' and 'gave_up'
+posted_items, matching the admin usage view's 7-day failure metric
+(_admin_usage). Bug review 2026-09-09 finding #12.
+"""
+
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from database import get_db, init_db
+
+
+@pytest.fixture
+def temp_db(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        monkeypatch.setattr("database.DB_PATH", db_path)
+        init_db()
+        yield db_path
+
+
+@pytest.fixture
+def client(temp_db, monkeypatch):
+    import app as app_module
+
+    monkeypatch.setattr(app_module.settings, "AUTH_TOKEN", None)
+    return TestClient(app_module.app)
+
+
+def _seed_feed_and_echo():
+    with get_db() as db:
+        db.execute(
+            "INSERT INTO feeds (id, name, url, user_id) VALUES (1, 'F', 'https://example.com/f', 1)"
+        )
+        db.execute(
+            """INSERT INTO echoes (id, feed_id, destination_type, destination_id,
+                                   template, user_id, enabled)
+               VALUES (1, 1, 'email', 1, '{{ t }}', 1, 1)"""
+        )
+
+
+def _failed_stat_from_page(html: str) -> int:
+    m = re.search(
+        r'stat-value">(\d+)</span>\s*<span class="stat-label">Failed</span>', html
+    )
+    assert m, "Failed stat card not found in dashboard HTML"
+    return int(m.group(1))
+
+
+class TestDashboardFailedPostsStat:
+    def test_gave_up_posts_are_counted_as_failed(self, client, temp_db):
+        _seed_feed_and_echo()
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO posted_items (echo_id, item_id, item_title, status) VALUES (1, 'a', 'A', 'failed')"
+            )
+            db.execute(
+                "INSERT INTO posted_items (echo_id, item_id, item_title, status) VALUES (1, 'b', 'B', 'gave_up')"
+            )
+            db.execute(
+                "INSERT INTO posted_items (echo_id, item_id, item_title, status) VALUES (1, 'c', 'C', 'success')"
+            )
+            db.execute(
+                "INSERT INTO posted_items (echo_id, item_id, item_title, status) VALUES (1, 'd', 'D', 'queued')"
+            )
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        # 'failed' + 'gave_up' == 2; 'success' and 'queued' must not count.
+        assert _failed_stat_from_page(resp.text) == 2
+
+    def test_only_gave_up_posts_still_counted(self, client, temp_db):
+        """A feed whose only failures exhausted retries (no lingering
+        'failed' rows) must still surface a nonzero Failed stat."""
+        _seed_feed_and_echo()
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO posted_items (echo_id, item_id, item_title, status) VALUES (1, 'a', 'A', 'gave_up')"
+            )
+            db.execute(
+                "INSERT INTO posted_items (echo_id, item_id, item_title, status) VALUES (1, 'b', 'B', 'success')"
+            )
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert _failed_stat_from_page(resp.text) == 1

--- a/tests/test_feed_edit.py
+++ b/tests/test_feed_edit.py
@@ -5,6 +5,7 @@ IDs from the old feed are meaningless against the new one. Renames and
 interval-only edits must preserve the cursor.
 """
 
+import re
 import tempfile
 from pathlib import Path
 
@@ -247,9 +248,19 @@ class TestFeedEditInvalidatesSavedSearchCache:
             headers={"Accept": "application/json"},
         ).json()["id"]
 
+        def _saved_search_badge(html: str, search_id: int) -> int:
+            m = re.search(
+                r'href="/reader\?saved=%d(?:&amp;fulltext=1)?".*?</a>' % search_id,
+                html,
+                re.S,
+            )
+            assert m, f"saved search {search_id} link not found in page"
+            badge = re.search(r'reader-feed-unread">(\d+)</span>', m.group(0))
+            return int(badge.group(1)) if badge else 0
+
         # Populate the cache: unmuted, "widget" matches the one unread item.
         r1 = client.get(f"/reader?saved={s_id}")
-        assert '<span class="reader-feed-unread">1</span>' in r1.text
+        assert _saved_search_badge(r1.text, s_id) == 1
         assert 1 in app_module._saved_search_counts_cache._store
 
         # Mute "widget" on this feed via edit_feed.
@@ -266,4 +277,5 @@ class TestFeedEditInvalidatesSavedSearchCache:
         # Cache must be invalidated immediately, not stale until TTL expiry.
         assert 1 not in app_module._saved_search_counts_cache._store
         r2 = client.get(f"/reader?saved={s_id}")
+        assert _saved_search_badge(r2.text, s_id) == 0
         assert app_module._saved_search_counts_cache._store[1][2][s_id] == 0

--- a/tests/test_feed_edit.py
+++ b/tests/test_feed_edit.py
@@ -221,3 +221,49 @@ class TestFeedEdit:
         page = client.get("/feeds").text
         assert "<script>alert(1)</script>" not in page
         assert "&lt;script&gt;" in page
+
+
+class TestFeedEditInvalidatesSavedSearchCache:
+    """Bug review 2026-09-09 finding #14: mute_keywords (and folder_id) are
+    direct inputs to the saved-search unread-counts query, so edit_feed
+    must invalidate the cache, same as reader_mute/delete_feed do."""
+
+    def test_editing_mute_keywords_invalidates_cache(self, client, temp_db):
+        import app as app_module
+
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO feeds (id, name, url, poll_interval, read_enabled, user_id) "
+                "VALUES (1, 'Test Feed', 'https://example.com/feed.xml', 15, 1, 1)"
+            )
+            db.execute(
+                "INSERT INTO feed_items (feed_id, item_id, title, content, is_read) "
+                "VALUES (1, 'it-1', 'Breaking widget news', 'widget content', 0)"
+            )
+
+        s_id = client.post(
+            "/api/saved-searches",
+            data={"name": "Widgets", "query": "widget"},
+            headers={"Accept": "application/json"},
+        ).json()["id"]
+
+        # Populate the cache: unmuted, "widget" matches the one unread item.
+        r1 = client.get(f"/reader?saved={s_id}")
+        assert '<span class="reader-feed-unread">1</span>' in r1.text
+        assert 1 in app_module._saved_search_counts_cache._store
+
+        # Mute "widget" on this feed via edit_feed.
+        client.post(
+            "/api/feeds/1/edit",
+            data={
+                "name": "Test Feed",
+                "url": "https://example.com/feed.xml",
+                "poll_interval": "15",
+                "mute_keywords": "widget",
+            },
+        )
+
+        # Cache must be invalidated immediately, not stale until TTL expiry.
+        assert 1 not in app_module._saved_search_counts_cache._store
+        r2 = client.get(f"/reader?saved={s_id}")
+        assert app_module._saved_search_counts_cache._store[1][2][s_id] == 0

--- a/tests/test_reader_folders.py
+++ b/tests/test_reader_folders.py
@@ -3,6 +3,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
+import app as app_module
 import database
 import settings
 from app import app
@@ -138,3 +139,93 @@ def test_reader_mark_folder_read(folder_env):
         tech = db.execute("SELECT is_read FROM feed_items WHERE id = 1").fetchone()
     assert sci["is_read"] == 1
     assert tech["is_read"] == 0
+
+
+def _create_saved_search(client, name, query):
+    r = client.post(
+        "/api/saved-searches",
+        data={"name": name, "query": query},
+        headers={"Accept": "application/json"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+def test_rename_folder_invalidates_saved_search_counts_cache(folder_env):
+    """Bug review 2026-09-09 finding #14: renaming a folder that a saved
+    search filters on (folder:<name>) must invalidate the cached counts
+    immediately, not just on TTL expiry."""
+    with database.get_db() as db:
+        db.execute("INSERT INTO folders (user_id, name, position) VALUES (1, 'Computing', 1)")
+        fid = db.execute("SELECT id FROM folders WHERE name = 'Computing'").fetchone()["id"]
+        db.execute("UPDATE feeds SET folder_id = ? WHERE id = 1", (fid,))
+
+    client = TestClient(app)
+    s_id = _create_saved_search(client, "Computing Folder", "folder:computing")
+
+    # Populate the cache: "folder:computing" matches Tech Post 1 (feed 1).
+    r1 = client.get(f"/reader?saved={s_id}")
+    assert '<span class="reader-feed-unread">1</span>' in r1.text
+    assert 1 in app_module._saved_search_counts_cache._store
+
+    # Rename the folder so "folder:computing" no longer matches anything.
+    r_ren = client.post(f"/api/folders/{fid}/rename", data={"name": "Renamed"}, follow_redirects=False)
+    assert r_ren.status_code == 303
+
+    # The cache entry must be gone so the next read recomputes...
+    assert 1 not in app_module._saved_search_counts_cache._store
+    # ...and the recomputed count must reflect the rename immediately (0
+    # matches now; a 0 count renders no badge span at all, so read the
+    # cache directly rather than parsing the page for an absent element).
+    r2 = client.get(f"/reader?saved={s_id}")
+    assert r2.status_code == 200
+    cached = app_module._saved_search_counts_cache._store[1]
+    assert cached[2][s_id] == 0
+
+
+def test_set_feed_folder_invalidates_saved_search_counts_cache(folder_env):
+    """Moving a feed into/out of a folder changes folder:<name> saved-search
+    membership, so it must invalidate the counts cache too."""
+    with database.get_db() as db:
+        db.execute("INSERT INTO folders (user_id, name, position) VALUES (1, 'Computing', 1)")
+        fid = db.execute("SELECT id FROM folders WHERE name = 'Computing'").fetchone()["id"]
+
+    client = TestClient(app)
+    s_id = _create_saved_search(client, "Computing Folder", "folder:computing")
+
+    # No feed is in the folder yet.
+    r1 = client.get(f"/reader?saved={s_id}")
+    assert r1.status_code == 200
+    assert app_module._saved_search_counts_cache._store[1][2][s_id] == 0
+
+    # Move feed 1 (Tech Post 1, unread) into the folder.
+    r_assign = client.post("/api/feeds/1/folder", data={"folder_id": str(fid)})
+    assert r_assign.status_code == 200
+
+    assert 1 not in app_module._saved_search_counts_cache._store
+    r2 = client.get(f"/reader?saved={s_id}")
+    assert '<span class="reader-feed-unread">1</span>' in r2.text
+
+
+def test_delete_folder_invalidates_saved_search_counts_cache(folder_env):
+    """Deleting a folder that a saved search filters on must invalidate the
+    counts cache immediately."""
+    with database.get_db() as db:
+        db.execute("INSERT INTO folders (user_id, name, position) VALUES (1, 'Computing', 1)")
+        fid = db.execute("SELECT id FROM folders WHERE name = 'Computing'").fetchone()["id"]
+        db.execute("UPDATE feeds SET folder_id = ? WHERE id = 1", (fid,))
+
+    client = TestClient(app)
+    s_id = _create_saved_search(client, "Computing Folder", "folder:computing")
+
+    r1 = client.get(f"/reader?saved={s_id}")
+    assert '<span class="reader-feed-unread">1</span>' in r1.text
+    assert 1 in app_module._saved_search_counts_cache._store
+
+    r_del = client.post(f"/api/folders/{fid}/delete", follow_redirects=False)
+    assert r_del.status_code == 303
+
+    assert 1 not in app_module._saved_search_counts_cache._store
+    r2 = client.get(f"/reader?saved={s_id}")
+    assert r2.status_code == 200
+    assert app_module._saved_search_counts_cache._store[1][2][s_id] == 0

--- a/tests/test_reader_folders.py
+++ b/tests/test_reader_folders.py
@@ -1,5 +1,6 @@
 """Tests for reader folders (Phase 1.1)."""
 
+import re
 import pytest
 from fastapi.testclient import TestClient
 
@@ -151,6 +152,18 @@ def _create_saved_search(client, name, query):
     return r.json()["id"]
 
 
+def _saved_search_badge(html: str, s_id: int) -> int:
+    """Extract the sidebar count badge for one saved search's link."""
+    m = re.search(
+        r'href="/reader\?saved=%d(?:&amp;fulltext=1)?".*?</a>' % s_id,
+        html,
+        re.S,
+    )
+    assert m, f"saved search {s_id} link not found in page"
+    badge = re.search(r'reader-feed-unread">(\d+)</span>', m.group(0))
+    return int(badge.group(1)) if badge else 0
+
+
 def test_rename_folder_invalidates_saved_search_counts_cache(folder_env):
     """Bug review 2026-09-09 finding #14: renaming a folder that a saved
     search filters on (folder:<name>) must invalidate the cached counts
@@ -165,7 +178,7 @@ def test_rename_folder_invalidates_saved_search_counts_cache(folder_env):
 
     # Populate the cache: "folder:computing" matches Tech Post 1 (feed 1).
     r1 = client.get(f"/reader?saved={s_id}")
-    assert '<span class="reader-feed-unread">1</span>' in r1.text
+    assert _saved_search_badge(r1.text, s_id) == 1
     assert 1 in app_module._saved_search_counts_cache._store
 
     # Rename the folder so "folder:computing" no longer matches anything.
@@ -175,10 +188,10 @@ def test_rename_folder_invalidates_saved_search_counts_cache(folder_env):
     # The cache entry must be gone so the next read recomputes...
     assert 1 not in app_module._saved_search_counts_cache._store
     # ...and the recomputed count must reflect the rename immediately (0
-    # matches now; a 0 count renders no badge span at all, so read the
-    # cache directly rather than parsing the page for an absent element).
+    # matches now; a 0 count renders no badge span at all).
     r2 = client.get(f"/reader?saved={s_id}")
     assert r2.status_code == 200
+    assert _saved_search_badge(r2.text, s_id) == 0
     cached = app_module._saved_search_counts_cache._store[1]
     assert cached[2][s_id] == 0
 
@@ -196,6 +209,7 @@ def test_set_feed_folder_invalidates_saved_search_counts_cache(folder_env):
     # No feed is in the folder yet.
     r1 = client.get(f"/reader?saved={s_id}")
     assert r1.status_code == 200
+    assert _saved_search_badge(r1.text, s_id) == 0
     assert app_module._saved_search_counts_cache._store[1][2][s_id] == 0
 
     # Move feed 1 (Tech Post 1, unread) into the folder.
@@ -204,7 +218,7 @@ def test_set_feed_folder_invalidates_saved_search_counts_cache(folder_env):
 
     assert 1 not in app_module._saved_search_counts_cache._store
     r2 = client.get(f"/reader?saved={s_id}")
-    assert '<span class="reader-feed-unread">1</span>' in r2.text
+    assert _saved_search_badge(r2.text, s_id) == 1
 
 
 def test_delete_folder_invalidates_saved_search_counts_cache(folder_env):
@@ -219,7 +233,7 @@ def test_delete_folder_invalidates_saved_search_counts_cache(folder_env):
     s_id = _create_saved_search(client, "Computing Folder", "folder:computing")
 
     r1 = client.get(f"/reader?saved={s_id}")
-    assert '<span class="reader-feed-unread">1</span>' in r1.text
+    assert _saved_search_badge(r1.text, s_id) == 1
     assert 1 in app_module._saved_search_counts_cache._store
 
     r_del = client.post(f"/api/folders/{fid}/delete", follow_redirects=False)
@@ -228,4 +242,28 @@ def test_delete_folder_invalidates_saved_search_counts_cache(folder_env):
     assert 1 not in app_module._saved_search_counts_cache._store
     r2 = client.get(f"/reader?saved={s_id}")
     assert r2.status_code == 200
+    assert _saved_search_badge(r2.text, s_id) == 0
     assert app_module._saved_search_counts_cache._store[1][2][s_id] == 0
+
+
+def test_import_opml_invalidates_saved_search_counts_cache(folder_env):
+    """OPML import can create folders and feeds that saved searches filter on,
+    so it must invalidate the counts cache."""
+    client = TestClient(app)
+    s_id = _create_saved_search(client, "Imported Folder", "folder:imported")
+
+    r1 = client.get(f"/reader?saved={s_id}")
+    assert r1.status_code == 200
+    assert 1 in app_module._saved_search_counts_cache._store
+    assert app_module._saved_search_counts_cache._store[1][2][s_id] == 0
+
+    opml = (
+        '<?xml version="1.0"?><opml version="2.0"><body>'
+        '<outline text="Imported">'
+        '  <outline text="New Feed" xmlUrl="https://example.com/new.xml"/>'
+        '</outline>'
+        '</body></opml>'
+    )
+    r_import = client.post("/api/feeds/opml", data={"opml": opml}, follow_redirects=False)
+    assert r_import.status_code == 303
+    assert 1 not in app_module._saved_search_counts_cache._store

--- a/tests/test_reader_saved_searches.py
+++ b/tests/test_reader_saved_searches.py
@@ -1,5 +1,7 @@
 """Tests for Reader Phase 5: Saved Searches as Smart Feeds."""
 
+import re
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -8,6 +10,24 @@ import security
 import settings
 from app import app
 import scheduler
+
+
+def _saved_search_badge(html: str, s_id: int) -> int:
+    """Extract the sidebar unread-count badge for one saved search's link.
+
+    Both the per-feed unread badge and the saved-search badge share the
+    ``reader-feed-unread`` class, so a plain substring/regex search over
+    the whole page can accidentally match the wrong badge when the two
+    counts collide. Scope the search to the saved search's own <a> block.
+    """
+    m = re.search(
+        r'href="/reader\?saved=%d(?:&amp;fulltext=1)?".*?</a>' % s_id,
+        html,
+        re.S,
+    )
+    assert m, f"saved search {s_id} link not found in page"
+    badge = re.search(r'reader-feed-unread">(\d+)</span>', m.group(0))
+    return int(badge.group(1)) if badge else 0
 
 
 @pytest.fixture()
@@ -137,6 +157,33 @@ def test_reader_saved_search_view_and_counts(p5_env):
     assert "AI Breakthrough announced" in html
     # and should NOT show "Old AI Paper" because of is:unread
     assert "Old AI Paper" not in html
+
+
+def test_saved_search_badge_matches_page_when_no_is_operator(p5_env):
+    """A saved search with no is: operator must show a sidebar badge count
+    equal to the number of items the saved search page itself displays
+    (all matches, read or not) — not an unread-only count. Bug review
+    2026-09-09 finding #13.
+    """
+    r_create = p5_env.post(
+        "/api/saved-searches",
+        data={"name": "AI Everything", "query": "AI"},
+        headers={"Accept": "application/json"},
+    )
+    s_id = r_create.json()["id"]
+
+    r_page = p5_env.get(f"/reader?saved={s_id}")
+    assert r_page.status_code == 200
+    html = r_page.text
+
+    # "AI" matches it-1 (unread, starred) and it-3 (read); it-2 has no "AI".
+    # The page itself shows both, regardless of read state.
+    assert "AI Breakthrough announced" in html
+    assert "Old AI Paper" in html
+    assert "General Technology Update" not in html
+
+    # The sidebar badge must agree with that: 2, not the unread-only count (1).
+    assert _saved_search_badge(html, s_id) == 2
 
 
 def test_saved_searches_plan_allowance_enforced(p5_env):


### PR DESCRIPTION
## Summary
- Dashboard's "Failed" stat counted only `pi.status = 'failed'`, excluding `'gave_up'` (the terminal status for posts that exhausted their retry budget) — understating the most significant failure class, unlike the admin usage view which correctly counts both. Now `WHERE pi.status IN ('failed', 'gave_up')`.
- Saved-search sidebar badge counted unread-only by default while the actual `/reader?saved=<id>` page shows all matches regardless of read state (the `is:unread` implicit filter is unreachable whenever the saved query text is non-empty, which it always is) — the badge and the page it links to disagreed for every saved search without an explicit `is:` operator. Aligned the badge count to match the page's actual (intentional, documented) behavior.
- `edit_feed`, `rename_folder`, `delete_folder`, and `set_feed_folder` all mutate fields the saved-search counts cache depends on (`mute_keywords`, `folder_id`, folder membership/name) but never invalidated it, unlike `reader_mute`/`delete_feed`/etc. Added `_saved_search_counts_cache.invalidate(uid)` to all four routes.

Fixes `docs/reviews/2026-09-09-bug-review.md` findings #12, #13, #14.

## Test plan
- `FEEDECHO_MODE=single pytest -m "not pg and not multi" -q` → 1469 passed, 1 skipped, no regressions.
- New/extended tests in `tests/test_dashboard_stats.py`, `tests/test_feed_edit.py`, `tests/test_reader_folders.py`, `tests/test_reader_saved_searches.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ