### PR TITLE
fix(db): Postgres schema parity, UTC-pinned timestamps, and missing UNIQUE constraints

### DIFF
--- a/app.py
+++ b/app.py
@@ -3289,10 +3289,18 @@ async def add_account(
     uid = current_user_id(request)
     instance = validate_url(instance)
     with get_db() as db:
-        try:
-            _check_destination_cap(db, uid)
-        except PlanError as e:
-            return _render_accounts_error(request, str(e))
+        # Cap NEW rows only: re-adding an existing account is an upsert that
+        # changes nothing the cap measures.
+        existing = db.execute(
+            "SELECT id FROM accounts"
+            " WHERE user_id = ? AND instance = ? AND username = ?",
+            (uid, instance, username or name),
+        ).fetchone()
+        if existing is None:
+            try:
+                _check_destination_cap(db, uid)
+            except PlanError as e:
+                return _render_accounts_error(request, str(e))
         db.execute(
             """
             INSERT INTO accounts (name, username, instance, access_token, user_id)
@@ -4490,16 +4498,28 @@ async def add_feed(
             if not folder:
                 target_folder_id = None
         if settings.MULTI:
-            plan = _user_plan(db, uid)
-            count = db.execute(
-                "SELECT COUNT(*) AS c FROM feeds WHERE user_id = ? AND deleted_at IS NULL",
-                (uid,),
-            ).fetchone()["c"]
-            try:
-                plans.check_feed_allowance(count, plan)
-            except PlanError as e:
-                raise HTTPException(status_code=402, detail=str(e))
-            poll_interval = plans.clamp_poll_interval(poll_interval, plan)
+            # Cap NEW rows only: re-adding an existing URL is an upsert that
+            # changes nothing the cap measures.
+            existing_feed = db.execute(
+                "SELECT id FROM feeds"
+                " WHERE user_id = ? AND url = ? AND deleted_at IS NULL",
+                (uid, url),
+            ).fetchone()
+            if existing_feed is None:
+                plan = _user_plan(db, uid)
+                count = db.execute(
+                    "SELECT COUNT(*) AS c FROM feeds WHERE user_id = ? AND deleted_at IS NULL",
+                    (uid,),
+                ).fetchone()["c"]
+                try:
+                    plans.check_feed_allowance(count, plan)
+                except PlanError as e:
+                    raise HTTPException(status_code=402, detail=str(e))
+                poll_interval = plans.clamp_poll_interval(poll_interval, plan)
+            else:
+                poll_interval = plans.clamp_poll_interval(
+                    poll_interval, _user_plan(db, uid)
+                )
         db.execute(
             """
             INSERT INTO feeds (name, url, poll_interval, user_id, folder_id)
@@ -4656,12 +4676,19 @@ def import_opml(
                             capped += 1
                             continue
                     title = (child.get("title") or child.get("text") or "").strip() or valid_url
-                    db.execute(
-                        "INSERT INTO feeds (name, url, read_enabled, user_id, folder_id) VALUES (?, ?, ?, ?, ?)",
+                    row = db.execute(
+                        "INSERT INTO feeds (name, url, read_enabled, user_id, folder_id)"
+                        " VALUES (?, ?, ?, ?, ?)"
+                        " ON CONFLICT(user_id, url) WHERE deleted_at IS NULL DO NOTHING",
                         (title, valid_url, 1 if reader_allowed else 0, uid, current_folder_id),
                     )
-                    existing_urls.add(valid_url)
-                    imported += 1
+                    if row.rowcount == 0:
+                        # Lost a race with a concurrent add/import of the same
+                        # user+url: count it as a duplicate, not a 500.
+                        duplicate += 1
+                    else:
+                        existing_urls.add(valid_url)
+                        imported += 1
                 else:
                     # Folder / container outline
                     folder_name = (child.get("title") or child.get("text") or "").strip()
@@ -6120,10 +6147,18 @@ def oauth_callback(
         username = "unknown"
 
     with get_db() as db:
-        try:
-            _check_destination_cap(db, state_user_id or 1)
-        except PlanError as e:
-            return _render_oauth_error(request, str(e))
+        # Cap NEW rows only: reconnecting an existing account is an upsert
+        # that changes nothing the cap measures.
+        existing = db.execute(
+            "SELECT id FROM accounts"
+            " WHERE user_id = ? AND instance = ? AND username = ?",
+            (state_user_id or 1, instance, username),
+        ).fetchone()
+        if existing is None:
+            try:
+                _check_destination_cap(db, state_user_id or 1)
+            except PlanError as e:
+                return _render_oauth_error(request, str(e))
         db.execute(
             """
             INSERT INTO accounts (name, username, instance, access_token, user_id)

--- a/app.py
+++ b/app.py
@@ -3217,8 +3217,13 @@ async def add_account(
         except PlanError as e:
             return _render_accounts_error(request, str(e))
         db.execute(
-            "INSERT INTO accounts (name, username, instance, access_token, user_id)"
-            " VALUES (?, ?, ?, ?, ?)",
+            """
+            INSERT INTO accounts (name, username, instance, access_token, user_id)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, instance, username) DO UPDATE SET
+                name = excluded.name,
+                access_token = excluded.access_token
+            """,
             (name, username or name, instance, security.encrypt_secret(access_token), uid),
         )
     return RedirectResponse(url="/accounts", status_code=303)
@@ -4410,7 +4415,14 @@ async def add_feed(
                 raise HTTPException(status_code=402, detail=str(e))
             poll_interval = plans.clamp_poll_interval(poll_interval, plan)
         db.execute(
-            "INSERT INTO feeds (name, url, poll_interval, user_id, folder_id) VALUES (?, ?, ?, ?, ?)",
+            """
+            INSERT INTO feeds (name, url, poll_interval, user_id, folder_id)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, url) WHERE deleted_at IS NULL DO UPDATE SET
+                name = excluded.name,
+                poll_interval = excluded.poll_interval,
+                folder_id = excluded.folder_id
+            """,
             (name, url, poll_interval, uid, target_folder_id),
         )
     return RedirectResponse(url="/feeds", status_code=303)
@@ -5969,8 +5981,13 @@ def oauth_callback(
         except PlanError as e:
             return _render_oauth_error(request, str(e))
         db.execute(
-            """INSERT INTO accounts (name, username, instance, access_token, user_id)
-               VALUES (?, ?, ?, ?, ?)""",
+            """
+            INSERT INTO accounts (name, username, instance, access_token, user_id)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, instance, username) DO UPDATE SET
+                name = excluded.name,
+                access_token = excluded.access_token
+            """,
             (display_name, username, instance, security.encrypt_secret(access_token), state_user_id or 1),
         )
 

--- a/database.py
+++ b/database.py
@@ -133,15 +133,19 @@ def _pg_connect():
             "pip install 'feedecho[postgres]'"
         ) from exc
     conn = psycopg.connect(
-        settings.DATABASE_URL, row_factory=psycopg.rows.dict_row
+        settings.DATABASE_URL,
+        row_factory=psycopg.rows.dict_row,
+        # Pin the session timezone to UTC at the handshake itself (not via a
+        # post-connect SET, which runs inside psycopg3's implicit transaction
+        # and reverts to the server default on any ROLLBACK, leaving later
+        # statements on the same connection skewed).
+        options="-c timezone=UTC",
     )
-    # Pin the session timezone to UTC. Postgres's CURRENT_TIMESTAMP/NOW()
-    # resolve in the session/server timezone before being cast into our
-    # naive TIMESTAMP columns (unlike sqlite's CURRENT_TIMESTAMP, which is
-    # always UTC) — without this, a non-UTC server timezone silently skews
-    # every stored timestamp relative to as_utc_naive()/timestamp_str()'s
-    # UTC assumption.
-    conn.execute("SET TIME ZONE 'UTC'")
+    # Postgres's CURRENT_TIMESTAMP/NOW() resolve in the session/server
+    # timezone before being cast into our naive TIMESTAMP columns (unlike
+    # sqlite's CURRENT_TIMESTAMP, which is always UTC) — without this, a
+    # non-UTC server timezone silently skews every stored timestamp
+    # relative to as_utc_naive()/timestamp_str()'s UTC assumption.
     return conn
 
 
@@ -240,6 +244,95 @@ def _dedupe_discord_webhook_hashes(db) -> None:
             " WHERE user_id = ? AND webhook_url_hash = ? AND id != ?",
             (d["user_id"], d["webhook_url_hash"], d["keep_id"]),
         )
+
+
+def _dedupe_accounts_for_unique_index(db) -> None:
+    """Collapse duplicate (user_id, instance, username) account rows before
+    the unique index is built.
+
+    Pre-upgrade ``oauth_callback`` and ``add_account`` were plain INSERTs on
+    every reconnect, so long-lived installs can already hold multiple rows
+    for the same logical account; CREATE UNIQUE INDEX over them would crash
+    init_db at boot (the v1.39.0 Discord-hash failure class). Keep the
+    highest id per group — the most recent reconnect carries the freshest
+    token and display name — repoint the references that make rows distinct
+    accounts (echoes + queued_posts by destination), then delete the older
+    rows. Runs best-effort: the index creation below is the hard gate.
+    """
+    dupes = db.execute(
+        "SELECT user_id, instance, username, MAX(id) AS keep_id"
+        " FROM accounts"
+        " GROUP BY user_id, instance, username HAVING COUNT(*) > 1"
+    ).fetchall()
+    for d in dupes:
+        keep_id = d["keep_id"]
+        stale = db.execute(
+            "SELECT id FROM accounts"
+            " WHERE user_id = ? AND instance = ? AND username = ? AND id != ?",
+            (d["user_id"], d["instance"], d["username"], keep_id),
+        ).fetchall()
+        for s in stale:
+            old_id = s["id"]
+            db.execute(
+                "UPDATE echoes SET destination_id = ?"
+                " WHERE destination_type = 'mastodon' AND destination_id = ?",
+                (keep_id, old_id),
+            )
+            db.execute(
+                "UPDATE queued_posts SET destination_id = ?"
+                " WHERE destination_type = 'mastodon' AND destination_id = ?",
+                (keep_id, old_id),
+            )
+            db.execute("DELETE FROM accounts WHERE id = ?", (old_id,))
+
+
+def _dedupe_feeds_for_unique_index(db) -> None:
+    """Collapse duplicate active (user_id, url) feed rows before the unique
+    index is built.
+
+    Same pre-upgrade plain-INSERT exposure as accounts. Keep the lowest id
+    per group — the original feed, with its poll state and item history —
+    repoint echoes/queued_posts, merge feed_items (delete items that would
+    collide on the destination feed's (feed_id, item_id) unique index, then
+    repoint the rest), and soft-delete the duplicate rows so the partial
+    index accepts them while posted_items history stays intact.
+    """
+    dupes = db.execute(
+        "SELECT user_id, url, MIN(id) AS keep_id"
+        " FROM feeds WHERE deleted_at IS NULL"
+        " GROUP BY user_id, url HAVING COUNT(*) > 1"
+    ).fetchall()
+    for d in dupes:
+        keep_id = d["keep_id"]
+        stale = db.execute(
+            "SELECT id FROM feeds"
+            " WHERE user_id = ? AND url = ? AND deleted_at IS NULL AND id != ?",
+            (d["user_id"], d["url"], keep_id),
+        ).fetchall()
+        for s in stale:
+            old_id = s["id"]
+            db.execute(
+                "UPDATE echoes SET feed_id = ? WHERE feed_id = ?",
+                (keep_id, old_id),
+            )
+            db.execute(
+                "UPDATE queued_posts SET feed_id = ? WHERE feed_id = ?",
+                (keep_id, old_id),
+            )
+            db.execute(
+                "DELETE FROM feed_items"
+                " WHERE feed_id = ? AND item_id IN"
+                " (SELECT item_id FROM feed_items WHERE feed_id = ?)",
+                (old_id, keep_id),
+            )
+            db.execute(
+                "UPDATE feed_items SET feed_id = ? WHERE feed_id = ?",
+                (keep_id, old_id),
+            )
+            db.execute(
+                "UPDATE feeds SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (old_id,),
+            )
 
 
 def prune_feed_items(db, feed_id: int, limit: int | None = None) -> None:
@@ -911,6 +1004,12 @@ def init_db_sqlite() -> None:
         # ignores deleted_at IS NOT NULL rows (see get_feeds/its INSERT
         # dedup query) — a non-partial index would otherwise permanently
         # block re-adding a feed URL after it was deleted.
+        # Pre-upgrade inserts were unguarded (oauth_callback re-connected
+        # via plain INSERT), so already-deployed databases can hold exact
+        # duplicate rows; dedupe them first or CREATE UNIQUE INDEX fails at
+        # boot (the v1.39.0 Discord-hash failure class).
+        _dedupe_feeds_for_unique_index(db)
+        _dedupe_accounts_for_unique_index(db)
         db.execute("""
             CREATE UNIQUE INDEX IF NOT EXISTS idx_feeds_user_url
             ON feeds(user_id, url)
@@ -1493,6 +1592,12 @@ def init_db_postgres() -> None:
         # ignores deleted_at IS NOT NULL rows (see get_feeds/its INSERT
         # dedup query) — a non-partial index would otherwise permanently
         # block re-adding a feed URL after it was deleted.
+        # Pre-upgrade inserts were unguarded (oauth_callback re-connected
+        # via plain INSERT), so already-deployed databases can hold exact
+        # duplicate rows; dedupe them first or CREATE UNIQUE INDEX fails at
+        # boot (the v1.39.0 Discord-hash failure class).
+        _dedupe_feeds_for_unique_index(db)
+        _dedupe_accounts_for_unique_index(db)
         db.execute("""
             CREATE UNIQUE INDEX IF NOT EXISTS idx_feeds_user_url
             ON feeds(user_id, url)

--- a/database.py
+++ b/database.py
@@ -273,6 +273,39 @@ def _dedupe_accounts_for_unique_index(db) -> None:
         ).fetchall()
         for s in stale:
             old_id = s["id"]
+            # Echoes that would collide after the repoint (an echo already
+            # points at the surviving account from the same feed): merge post
+            # history into the surviving echo, then drop the duplicate — a
+            # blind repoint would double-post every item to the destination.
+            collisions = db.execute(
+                "SELECT o.id AS old_echo_id, k.id AS keep_echo_id"
+                " FROM echoes o JOIN echoes k"
+                " ON k.user_id = o.user_id AND k.feed_id = o.feed_id"
+                " AND k.destination_type = o.destination_type"
+                " AND k.destination_id = ?"
+                " AND k.deleted_at IS NULL"
+                " WHERE o.destination_type = 'mastodon' AND o.destination_id = ?"
+                " AND o.deleted_at IS NULL",
+                (keep_id, old_id),
+            ).fetchall()
+            for c in collisions:
+                db.execute(
+                    "UPDATE posted_items SET echo_id = ? WHERE echo_id = ?",
+                    (c["keep_echo_id"], c["old_echo_id"]),
+                )
+                db.execute("DELETE FROM echoes WHERE id = ?", (c["old_echo_id"],))
+            # Duplicate queued jobs for the same item, pointing at the old
+            # account while a queued job for the survivor already exists.
+            db.execute(
+                "DELETE FROM queued_posts"
+                " WHERE destination_type = 'mastodon' AND destination_id = ?"
+                " AND status = 'queued'"
+                " AND EXISTS (SELECT 1 FROM queued_posts q2 WHERE q2.feed_id = queued_posts.feed_id"
+                " AND q2.item_id = queued_posts.item_id"
+                " AND q2.destination_type = 'mastodon'"
+                " AND q2.destination_id = ? AND q2.status = 'queued')",
+                (old_id, keep_id),
+            )
             db.execute(
                 "UPDATE echoes SET destination_id = ?"
                 " WHERE destination_type = 'mastodon' AND destination_id = ?",
@@ -311,6 +344,38 @@ def _dedupe_feeds_for_unique_index(db) -> None:
         ).fetchall()
         for s in stale:
             old_id = s["id"]
+            # Echoes that would collide after the repoint (the surviving feed
+            # already has an echo to the same destination): preserve their
+            # post history by moving posted_items to the surviving echo, then
+            # drop the duplicate echo. A blind repoint here would leave two
+            # identical echoes on one feed and every item would post twice.
+            collisions = db.execute(
+                "SELECT o.id AS old_echo_id, k.id AS keep_echo_id"
+                " FROM echoes o JOIN echoes k"
+                " ON k.user_id = o.user_id AND k.feed_id = ?"
+                " AND k.destination_type = o.destination_type"
+                " AND k.destination_id = o.destination_id"
+                " AND k.deleted_at IS NULL"
+                " WHERE o.feed_id = ? AND o.deleted_at IS NULL",
+                (keep_id, old_id),
+            ).fetchall()
+            for c in collisions:
+                db.execute(
+                    "UPDATE posted_items SET echo_id = ? WHERE echo_id = ?",
+                    (c["keep_echo_id"], c["old_echo_id"]),
+                )
+                db.execute("DELETE FROM echoes WHERE id = ?", (c["old_echo_id"],))
+            # Duplicate queued jobs for the same item+destination (both feeds
+            # queued the item before the dedupe): keep the survivor's row.
+            db.execute(
+                "DELETE FROM queued_posts WHERE feed_id = ? AND status = 'queued'"
+                " AND EXISTS (SELECT 1 FROM queued_posts q2 WHERE q2.feed_id = ?"
+                " AND q2.item_id = queued_posts.item_id"
+                " AND q2.destination_type = queued_posts.destination_type"
+                " AND q2.destination_id = queued_posts.destination_id"
+                " AND q2.status = 'queued')",
+                (old_id, keep_id),
+            )
             db.execute(
                 "UPDATE echoes SET feed_id = ? WHERE feed_id = ?",
                 (keep_id, old_id),

--- a/database.py
+++ b/database.py
@@ -132,9 +132,17 @@ def _pg_connect():
             "PostgreSQL mode requires the psycopg package: "
             "pip install 'feedecho[postgres]'"
         ) from exc
-    return psycopg.connect(
+    conn = psycopg.connect(
         settings.DATABASE_URL, row_factory=psycopg.rows.dict_row
     )
+    # Pin the session timezone to UTC. Postgres's CURRENT_TIMESTAMP/NOW()
+    # resolve in the session/server timezone before being cast into our
+    # naive TIMESTAMP columns (unlike sqlite's CURRENT_TIMESTAMP, which is
+    # always UTC) — without this, a non-UTC server timezone silently skews
+    # every stored timestamp relative to as_utc_naive()/timestamp_str()'s
+    # UTC assumption.
+    conn.execute("SET TIME ZONE 'UTC'")
+    return conn
 
 
 @contextmanager
@@ -890,6 +898,29 @@ def init_db_sqlite() -> None:
             ON oauth_states(expires_at)
         """)
 
+        # DB-level dedup backing for import_export.py's check-then-insert
+        # logic: without this, two concurrent requests (e.g. two imports, or
+        # an import racing a manual add) for the same user+url/instance+
+        # username can both pass the SELECT before either INSERT commits,
+        # producing duplicate rows. A unique index (rather than an inline
+        # UNIQUE + table rebuild) applies retroactively to already-deployed
+        # databases without a risky recreate-table migration; run after
+        # user_id/username are guaranteed to exist on both tables above.
+        # Partial (WHERE deleted_at IS NULL): feeds are soft-deleted and
+        # never purged, and import_export.py's own dedup lookup already
+        # ignores deleted_at IS NOT NULL rows (see get_feeds/its INSERT
+        # dedup query) — a non-partial index would otherwise permanently
+        # block re-adding a feed URL after it was deleted.
+        db.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_feeds_user_url
+            ON feeds(user_id, url)
+            WHERE deleted_at IS NULL
+        """)
+        db.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_user_instance_username
+            ON accounts(user_id, instance, username)
+        """)
+
         # Best-effort cleanup of expired/consumed state rows.
         db.execute("""
             DELETE FROM oauth_states
@@ -1014,6 +1045,28 @@ def init_db_postgres() -> None:
             )
         """)
 
+        # Pre-existing hosted databases created before `username` shipped
+        # need the same backfill-from-`name` treatment as sqlite: fresh
+        # installs get the column from CREATE TABLE above, but that's a
+        # no-op on a table that already exists without it.
+        account_columns = _column_names(db, "accounts")
+        if "username" not in account_columns:
+            db.execute("ALTER TABLE accounts ADD COLUMN username TEXT DEFAULT ''")
+            rows = db.execute("SELECT id, name FROM accounts").fetchall()
+            import re
+
+            for row in rows:
+                match = re.search(r"\(([^)]+)\)$", row["name"] or "")
+                username = (
+                    match.group(1)
+                    if match
+                    else (row["name"] or "unknown")
+                )
+                db.execute(
+                    "UPDATE accounts SET username = ? WHERE id = ?",
+                    (username, row["id"]),
+                )
+
         db.execute("""
             CREATE TABLE IF NOT EXISTS saved_searches (
                 id BIGSERIAL PRIMARY KEY,
@@ -1070,6 +1123,12 @@ def init_db_postgres() -> None:
         _add_column_if_missing(db, "feeds", "mute_keywords", "TEXT DEFAULT ''")
         _add_column_if_missing(db, "feeds", "last_error", "TEXT")
         _add_column_if_missing(db, "feeds", "folder_id", "BIGINT")
+        _add_column_if_missing(db, "feeds", "lease_token", "TEXT")
+        _add_column_if_missing(db, "feeds", "lease_expires_at", "TIMESTAMP")
+        _add_column_if_missing(db, "feeds", "paused", "INTEGER NOT NULL DEFAULT 0")
+        # Soft-delete marker: feeds are never hard-deleted by the app so that
+        # echo configuration and posted-item history survive as an audit trail.
+        _add_column_if_missing(db, "feeds", "deleted_at", "TIMESTAMP")
 
         db.execute("""
             CREATE TABLE IF NOT EXISTS feed_items (
@@ -1136,6 +1195,21 @@ def init_db_postgres() -> None:
             )
         """)
         _add_column_if_missing(db, "echoes", "one_shot", "INTEGER NOT NULL DEFAULT 0")
+        _add_column_if_missing(db, "echoes", "filter_keywords", "TEXT DEFAULT ''")
+        _add_column_if_missing(
+            db, "echoes", "filter_mode", "TEXT NOT NULL DEFAULT 'exclude'"
+        )
+        _add_column_if_missing(db, "echoes", "content_warning", "TEXT DEFAULT ''")
+        _add_column_if_missing(
+            db, "echoes", "attach_image", "INTEGER NOT NULL DEFAULT 0"
+        )
+        _add_column_if_missing(
+            db, "echoes", "delivery_mode", "TEXT NOT NULL DEFAULT 'instant'"
+        )
+        _add_column_if_missing(
+            db, "echoes", "drip_limit", "INTEGER NOT NULL DEFAULT 0"
+        )
+        _add_column_if_missing(db, "echoes", "deleted_at", "TIMESTAMP")
 
         db.execute("""
             CREATE TABLE IF NOT EXISTS digest_items (
@@ -1283,6 +1357,16 @@ def init_db_postgres() -> None:
                 FOREIGN KEY (echo_id) REFERENCES echoes(id) ON DELETE CASCADE
             )
         """)
+        _add_column_if_missing(db, "posted_items", "claimed_at", "TIMESTAMP")
+        _add_column_if_missing(db, "posted_items", "claim_token", "TEXT")
+        _add_column_if_missing(db, "posted_items", "post_url", "TEXT")
+        _add_column_if_missing(
+            db,
+            "posted_items",
+            "attempt_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        )
+        _add_column_if_missing(db, "posted_items", "next_retry_at", "TIMESTAMP")
 
         db.execute("""
             CREATE TABLE IF NOT EXISTS queued_posts (
@@ -1394,6 +1478,29 @@ def init_db_postgres() -> None:
         db.execute("""
             CREATE INDEX IF NOT EXISTS idx_oauth_states_expiry
             ON oauth_states(expires_at)
+        """)
+
+        # DB-level dedup backing for import_export.py's check-then-insert
+        # logic: without this, two concurrent requests (e.g. two imports, or
+        # an import racing a manual add) for the same user+url/instance+
+        # username can both pass the SELECT before either INSERT commits,
+        # producing duplicate rows. A unique index (rather than an inline
+        # UNIQUE + table rebuild) applies retroactively to already-deployed
+        # databases without a risky recreate-table migration; run after
+        # user_id/username are guaranteed to exist on both tables above.
+        # Partial (WHERE deleted_at IS NULL): feeds are soft-deleted and
+        # never purged, and import_export.py's own dedup lookup already
+        # ignores deleted_at IS NOT NULL rows (see get_feeds/its INSERT
+        # dedup query) — a non-partial index would otherwise permanently
+        # block re-adding a feed URL after it was deleted.
+        db.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_feeds_user_url
+            ON feeds(user_id, url)
+            WHERE deleted_at IS NULL
+        """)
+        db.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_user_instance_username
+            ON accounts(user_id, instance, username)
         """)
 
         # Best-effort cleanup of expired/consumed state rows.

--- a/import_export.py
+++ b/import_export.py
@@ -393,6 +393,18 @@ def _clamp_drip(db, uid: int, drip_limit) -> int:
     return drip
 
 
+def _existing_feed_id(db, uid: int, url: str):
+    """The id of the user's existing active feed for ``url``, if any.
+
+    Mirrors ``_existing_account_id``: shared by the dedup pre-check and the
+    race fallback after an ``ON CONFLICT DO NOTHING`` insert.
+    """
+    return db.execute(
+        "SELECT id FROM feeds WHERE user_id = ? AND url = ? AND deleted_at IS NULL",
+        (uid, url),
+    ).fetchone()
+
+
 def import_data(db, uid: int, payload: dict) -> dict:
     """Import an export document for one user, returning a summary.
 
@@ -414,10 +426,7 @@ def import_data(db, uid: int, payload: dict) -> dict:
         url = str(feed.get("url") or "").strip()
         if not url:
             raise ExportError("Feed is missing a URL.")
-        existing = db.execute(
-            "SELECT id FROM feeds WHERE user_id = ? AND url = ? AND deleted_at IS NULL",
-            (uid, url),
-        ).fetchone()
+        existing = _existing_feed_id(db, uid, url)
         if existing:
             feed_map[old_id] = existing["id"]
             continue
@@ -466,7 +475,10 @@ def import_data(db, uid: int, payload: dict) -> dict:
         poll = _clamp_poll(db, uid, feed.get("poll_interval"))
         row = db.execute(
             "INSERT INTO feeds (name, url, feed_type, poll_interval, last_item_id,"
-            " paused, read_enabled, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id",
+            " paused, read_enabled, user_id)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+            " ON CONFLICT(user_id, url) WHERE deleted_at IS NULL DO NOTHING"
+            " RETURNING id",
             (
                 str(feed.get("name") or "").strip(),
                 url,
@@ -478,6 +490,12 @@ def import_data(db, uid: int, payload: dict) -> dict:
                 uid,
             ),
         ).fetchone()
+        if row is None:
+            # A concurrent request (another import, or a manual add) inserted
+            # the same user+url between our SELECT above and this INSERT: the
+            # unique index rejected the duplicate, so map onto the survivor
+            # instead of raising a bare IntegrityError.
+            row = _existing_feed_id(db, uid, url)
         for old_id in feed_oldids[url]:
             feed_map[old_id] = row["id"]
 
@@ -496,11 +514,24 @@ def import_data(db, uid: int, payload: dict) -> dict:
             ]
             placeholders = ", ".join("?" for _ in cols)
             column_list = ", ".join(cols)
+            key_cols = _KEY_COLS[section]
+            conflict_target = ", ".join(key_cols)
             row = db.execute(
                 f"INSERT INTO {table} ({column_list}, user_id)"
-                f" VALUES ({placeholders}, ?) RETURNING id",
+                f" VALUES ({placeholders}, ?)"
+                f" ON CONFLICT(user_id, {conflict_target}) DO NOTHING"
+                f" RETURNING id",
                 (*values, uid),
             ).fetchone()
+            if row is None:
+                # A concurrent request inserted the same natural key between
+                # our SELECT above and this INSERT: map onto the survivor
+                # instead of raising a bare IntegrityError.
+                clause = " AND ".join(f"{c} = ?" for c in key_cols)
+                row = db.execute(
+                    f"SELECT id FROM {table} WHERE user_id = ? AND {clause}",
+                    (uid, *key),
+                ).fetchone()
             for old_id in account_oldids[section][key]:
                 account_maps[section][old_id] = row["id"]
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -224,3 +224,122 @@ class TestAccountsUniqueConstraint:
                     " VALUES (?, ?, ?, ?, ?)",
                     ("Alice again", "alice", "https://example.com", "token2", 1),
                 )
+
+
+class TestUpgradeDedupe:
+    """Pre-upgrade databases can already hold duplicate rows the new unique
+    indexes would reject: oauth_callback/add_account were plain INSERTs on
+    every reconnect. init_db must dedupe them BEFORE building the indexes,
+    or the upgrade crashes at boot (v1.39.0 Discord-hash failure class)."""
+
+    def _make_legacy_duplicates(self, db):
+        db.execute("DROP INDEX IF EXISTS idx_feeds_user_url")
+        db.execute("DROP INDEX IF EXISTS idx_accounts_user_instance_username")
+        # Two accounts rows for the same logical account (user, instance,
+        # username) — the reconnect created a second row; echoes point at
+        # the OLD one.
+        db.execute(
+            "INSERT INTO accounts (name, username, instance, access_token, user_id)"
+            " VALUES ('Alice', 'alice', 'https://ex.com', 'old-token', 1)"
+        )
+        db.execute(
+            "INSERT INTO accounts (name, username, instance, access_token, user_id)"
+            " VALUES ('Alice new', 'alice', 'https://ex.com', 'new-token', 1)"
+        )
+        # Two ACTIVE feeds rows with the same (user_id, url) — feeds first,
+        # the echoes below carry an FK on feed_id.
+        db.execute(
+            "INSERT INTO feeds (name, url, user_id) VALUES ('F', 'https://ex.com/rss', 1)"
+        )
+        db.execute(
+            "INSERT INTO feeds (name, url, user_id) VALUES ('F2', 'https://ex.com/rss', 1)"
+        )
+        db.execute(
+            "INSERT INTO echoes (feed_id, destination_type, destination_id,"
+            " template, user_id) VALUES (1, 'mastodon', 1, 't', 1)"
+        )
+        db.execute(
+            "INSERT INTO queued_posts (user_id, item_id, feed_id,"
+            " destination_type, destination_id, content, scheduled_at)"
+            " VALUES (1, 'i1', 1, 'mastodon', 1, 'c', '2026-01-01 00:00:00')"
+        )
+        # Items on both rows: one collides with the kept feed's items, one
+        # must be repointed.
+        db.execute(
+            "INSERT INTO feed_items (feed_id, item_id, title) VALUES (1, 'i1', 'A')"
+        )
+        db.execute(
+            "INSERT INTO feed_items (feed_id, item_id, title) VALUES (2, 'i1', 'dup')"
+        )
+        db.execute(
+            "INSERT INTO feed_items (feed_id, item_id, title) VALUES (2, 'i2', 'keep')"
+        )
+
+    def test_init_db_survives_duplicate_rows_and_dedupes(self, temp_db):
+        with get_db() as db:
+            self._make_legacy_duplicates(db)
+
+        # Pre-fix, this raised IntegrityError from CREATE UNIQUE INDEX.
+        init_db()
+
+        with get_db() as db:
+            accounts = db.execute(
+                "SELECT id, username, access_token FROM accounts"
+            ).fetchall()
+            assert len(accounts) == 1
+            # MAX(id) survives: the freshest reconnect wins.
+            assert accounts[0]["username"] == "alice"
+            assert accounts[0]["access_token"] == "new-token"
+            echo = db.execute(
+                "SELECT destination_id FROM echoes"
+            ).fetchone()
+            assert echo["destination_id"] == accounts[0]["id"]
+            qp = db.execute(
+                "SELECT destination_id FROM queued_posts"
+            ).fetchone()
+            assert qp["destination_id"] == accounts[0]["id"]
+            active = db.execute(
+                "SELECT id, deleted_at FROM feeds ORDER BY id"
+            ).fetchall()
+            # MIN(id) survives; the duplicate is soft-deleted, never
+            # hard-deleted (posted_items history keeps pointing at it).
+            assert len(active) == 2
+            assert active[0]["deleted_at"] is None
+            assert active[1]["deleted_at"] is not None
+            items = db.execute(
+                "SELECT feed_id, item_id FROM feed_items ORDER BY item_id"
+            ).fetchall()
+            # Colliding item dropped, non-colliding item repointed to the
+            # kept feed.
+            assert [(r["feed_id"], r["item_id"]) for r in items] == [
+                (active[0]["id"], "i1"),
+                (active[0]["id"], "i2"),
+            ]
+            idx = db.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+                " AND name IN ('idx_feeds_user_url',"
+                " 'idx_accounts_user_instance_username')"
+            ).fetchall()
+            assert len(idx) == 2
+
+    def test_conflict_do_nothing_insert_reports_rowcount_zero(self, temp_db):
+        """The exact INSERT the OPML import route relies on: a conflicting
+        insert must be skipped silently and report rowcount 0, not raise."""
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id) VALUES ('F', 'https://x/rss', 1)"
+            )
+            cur = db.execute(
+                "INSERT INTO feeds (name, url, user_id)"
+                " VALUES (?, ?, ?)"
+                " ON CONFLICT(user_id, url) WHERE deleted_at IS NULL DO NOTHING",
+                ("F2", "https://x/rss", 1),
+            )
+            assert cur.rowcount == 0
+            cur2 = db.execute(
+                "INSERT INTO feeds (name, url, user_id)"
+                " VALUES (?, ?, ?)"
+                " ON CONFLICT(user_id, url) WHERE deleted_at IS NULL DO NOTHING",
+                ("F3", "https://x/other", 1),
+            )
+            assert cur2.rowcount == 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -111,3 +111,116 @@ class TestEchoes:
             )
             row = db.execute("SELECT value FROM settings WHERE key = 'smtp_host'").fetchone()
             assert row["value"] == "smtp.example.com"
+
+
+class TestAccountsUsernameMigration:
+    def test_username_backfilled_on_legacy_table(self, temp_db):
+        # Simulate a database created before `username` shipped on the
+        # accounts table (the same shape a pre-existing hosted Postgres
+        # database would have before finding #1's fix).
+        with get_db() as db:
+            db.execute("DROP TABLE accounts")
+            db.execute(
+                """
+                CREATE TABLE accounts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    instance TEXT NOT NULL,
+                    access_token TEXT NOT NULL,
+                    user_id INTEGER NOT NULL DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            db.execute(
+                "INSERT INTO accounts (name, instance, access_token) VALUES (?, ?, ?)",
+                ("Alice (alice)", "https://example.com", "token"),
+            )
+            db.execute(
+                "INSERT INTO accounts (name, instance, access_token) VALUES (?, ?, ?)",
+                ("Bob", "https://other.example.com", "token2"),
+            )
+
+        init_db()
+
+        with get_db() as db:
+            rows = db.execute(
+                "SELECT name, username FROM accounts ORDER BY id"
+            ).fetchall()
+        assert rows[0]["username"] == "alice"
+        assert rows[1]["username"] == "Bob"
+
+
+class TestFeedsUniqueConstraint:
+    def test_duplicate_user_url_rejected(self, temp_db):
+        import sqlite3
+
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id) VALUES (?, ?, ?)",
+                ("Feed", "https://example.com/feed.xml", 1),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            with get_db() as db:
+                db.execute(
+                    "INSERT INTO feeds (name, url, user_id) VALUES (?, ?, ?)",
+                    ("Feed dup", "https://example.com/feed.xml", 1),
+                )
+
+    def test_same_url_different_user_allowed(self, temp_db):
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id) VALUES (?, ?, ?)",
+                ("Feed", "https://example.com/feed.xml", 1),
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id) VALUES (?, ?, ?)",
+                ("Feed", "https://example.com/feed.xml", 2),
+            )
+            rows = db.execute("SELECT * FROM feeds").fetchall()
+        assert len(rows) == 2
+
+    def test_readd_after_soft_delete_allowed(self, temp_db):
+        """The unique index is partial (WHERE deleted_at IS NULL): feeds are
+        soft-deleted and never purged, and import_export.py's own dedup
+        lookup already ignores soft-deleted rows, so re-adding the same URL
+        after a delete must not be permanently blocked."""
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id) VALUES (?, ?, ?)",
+                ("Feed", "https://example.com/feed.xml", 1),
+            )
+            db.execute(
+                "UPDATE feeds SET deleted_at = CURRENT_TIMESTAMP"
+                " WHERE url = ? AND user_id = ?",
+                ("https://example.com/feed.xml", 1),
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id) VALUES (?, ?, ?)",
+                ("Feed again", "https://example.com/feed.xml", 1),
+            )
+            rows = db.execute(
+                "SELECT * FROM feeds WHERE url = ? AND user_id = ?",
+                ("https://example.com/feed.xml", 1),
+            ).fetchall()
+        assert len(rows) == 2
+
+
+class TestAccountsUniqueConstraint:
+    def test_duplicate_user_instance_username_rejected(self, temp_db):
+        import sqlite3
+
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO accounts (name, username, instance, access_token, user_id)"
+                " VALUES (?, ?, ?, ?, ?)",
+                ("Alice", "alice", "https://example.com", "token", 1),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            with get_db() as db:
+                db.execute(
+                    "INSERT INTO accounts"
+                    " (name, username, instance, access_token, user_id)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    ("Alice again", "alice", "https://example.com", "token2", 1),
+                )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -322,6 +322,43 @@ class TestUpgradeDedupe:
             ).fetchall()
             assert len(idx) == 2
 
+    def test_echo_collision_merged_not_duplicated(self, temp_db):
+        """If the surviving feed already has an echo to the same account, a
+        blind feed_id repoint of the duplicate feed's echo would leave TWO
+        identical echoes on one feed and every new item would post twice.
+        The dedupe must merge: posted_items move to the surviving echo and
+        the colliding echo is deleted."""
+        with get_db() as db:
+            self._make_legacy_duplicates(db)
+            # Base helper already created E1 (feed 1 = survivor, account 1).
+            # Add E2 on the DUPLICATE feed with the same destination: after
+            # the feed dedupe it would collide with E1 (same feed, same
+            # destination) and must be merged into it.
+            db.execute(
+                "INSERT INTO echoes (feed_id, destination_type, destination_id,"
+                " template, user_id) VALUES (2, 'mastodon', 1, 't', 1)"
+            )
+            db.execute(
+                "INSERT INTO posted_items (echo_id, item_id, status)"
+                " VALUES (2, 'i9', 'sent')"
+            )
+
+        init_db()
+
+        with get_db() as db:
+            echoes = db.execute(
+                "SELECT id, feed_id, destination_id FROM echoes"
+            ).fetchall()
+            assert len(echoes) == 1, (
+                "echo collision was not merged: duplicate echo survived"
+            )
+            posts = db.execute(
+                "SELECT echo_id, item_id FROM posted_items WHERE item_id = 'i9'"
+            ).fetchall()
+            # History preserved, moved onto the surviving echo.
+            assert len(posts) == 1
+            assert posts[0]["echo_id"] == echoes[0]["id"]
+
     def test_conflict_do_nothing_insert_reports_rowcount_zero(self, temp_db):
         """The exact INSERT the OPML import route relies on: a conflicting
         insert must be skipped silently and report rowcount 0, not raise."""

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -561,3 +561,79 @@ class TestReaderImportExport:
             ).fetchone()
         assert row["read_enabled"] == 0
 
+
+class TestConcurrentInsertRaces:
+    """The unique indexes turn a lost check-then-insert race into an
+    IntegrityError. Every insert path under an import must handle that
+    (ON CONFLICT DO NOTHING + survivor lookup), not 500."""
+
+    def test_feed_race_maps_onto_survivor(self, temp_db, monkeypatch):
+        payload = {
+            "format": "feedecho-export",
+            "version": 1,
+            "feeds": [{"id": 7, "name": "F", "url": "https://e.com/raced"}],
+            "accounts": {section: [] for section in import_export.ACCOUNT_TYPES},
+            "echoes": [],
+        }
+        real_clamp = import_export._clamp_poll
+
+        def clamp_and_race(db, uid, poll_interval):
+            # Runs after the import's dedup SELECT and before its INSERT:
+            # simulate a concurrent manual add winning the race.
+            with get_db() as db2:
+                db2.execute(
+                    "INSERT INTO feeds (name, url, user_id)"
+                    " VALUES ('Racer', 'https://e.com/raced', 1)"
+                )
+            return real_clamp(db, uid, poll_interval)
+
+        monkeypatch.setattr(import_export, "_clamp_poll", clamp_and_race)
+        with get_db() as db:
+            summary = import_export.import_data(db, 1, payload)
+            rows = db.execute(
+                "SELECT id, name FROM feeds WHERE url = 'https://e.com/raced'"
+            ).fetchall()
+        assert len(rows) == 1  # only the concurrent row survives
+        assert rows[0]["name"] == "Racer"
+        assert summary["added_feeds"] == 1  # mapped, not crashed
+
+    def test_account_race_maps_onto_survivor(self, temp_db, monkeypatch):
+        payload = {
+            "format": "feedecho-export",
+            "version": 1,
+            "feeds": [],
+            "accounts": {
+                "mastodon": [{
+                    "id": 9, "name": "A", "username": "alice",
+                    "instance": "https://m.example", "access_token": "tok",
+                }]
+            },
+            "echoes": [],
+        }
+        real_existing = import_export._existing_account_id
+
+        def existing_and_race(db, uid, section, account):
+            found = real_existing(db, uid, section, account)
+            if found is None and section == "mastodon":
+                # Runs after the import's dedup SELECT and before its
+                # INSERT: simulate a concurrent connect winning the race.
+                with get_db() as db2:
+                    db2.execute(
+                        "INSERT INTO accounts (name, username, instance,"
+                        " access_token, user_id)"
+                        " VALUES ('Racer', 'alice', 'https://m.example',"
+                        " 'racer-token', 1)"
+                    )
+            return found
+
+        monkeypatch.setattr(import_export, "_existing_account_id", existing_and_race)
+        with get_db() as db:
+            summary = import_export.import_data(db, 1, payload)
+            rows = db.execute(
+                "SELECT id, name, access_token FROM accounts"
+                " WHERE username = 'alice'"
+            ).fetchall()
+        assert len(rows) == 1  # only the concurrent row survives
+        assert rows[0]["name"] == "Racer"
+        assert summary["added_accounts"] == 1  # mapped, not crashed
+

--- a/tests/test_pg_dialect.py
+++ b/tests/test_pg_dialect.py
@@ -108,6 +108,22 @@ class TestPostgresInit:
 
 
 @requires_pg
+class TestPostgresSessionTimezone:
+    def test_connection_pins_session_timezone_to_utc(self, pg_env):
+        """_pg_connect must SET TIME ZONE 'UTC' immediately after connect.
+
+        Without this, CURRENT_TIMESTAMP/NOW() resolve in the server's
+        session timezone rather than UTC, silently skewing every naive
+        TIMESTAMP column against as_utc_naive()/timestamp_str()'s UTC
+        assumption whenever the Postgres server isn't itself running UTC.
+        """
+        database.init_db()
+        with database.get_db() as db:
+            tz = db.execute("SELECT current_setting('TimeZone') AS tz").fetchone()["tz"]
+        assert tz == "UTC"
+
+
+@requires_pg
 class TestPostgresRoundtrip:
     def test_qmark_placeholder_translation(self, pg_env):
         """`?` placeholders must work through the dialect layer on PG."""
@@ -296,6 +312,215 @@ class TestPostgresMigration:
         assert verification.consume_token(token, "verify") == 77
         # Single use on PG too
         assert verification.consume_token(token, "verify") is None
+
+    def test_accounts_username_backfilled_on_legacy_table(self, pg_env):
+        """A pre-existing hosted database created before `username` shipped
+        must get the same backfill-from-`name` treatment as sqlite."""
+        database.init_db()
+        with database.get_db() as db:
+            db.execute("DROP TABLE accounts")
+            db.execute("""
+                CREATE TABLE accounts (
+                    id BIGSERIAL PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    instance TEXT NOT NULL,
+                    access_token TEXT NOT NULL,
+                    user_id BIGINT NOT NULL DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            db.execute(
+                "INSERT INTO accounts (name, instance, access_token)"
+                " VALUES ('Alice (alice)', 'https://example.com', 'token')"
+            )
+            db.execute(
+                "INSERT INTO accounts (name, instance, access_token)"
+                " VALUES ('Bob', 'https://other.example.com', 'token2')"
+            )
+
+        database.init_db()
+
+        with database.get_db() as db:
+            rows = db.execute(
+                "SELECT name, username FROM accounts ORDER BY id"
+            ).fetchall()
+        assert rows[0]["username"] == "alice"
+        assert rows[1]["username"] == "Bob"
+
+    def test_feeds_legacy_columns_backfilled_on_pg(self, pg_env):
+        """Columns sqlite backfills for pre-existing feeds tables must also
+        be backfilled on Postgres, not just present via CREATE TABLE IF NOT
+        EXISTS (which is a no-op on a table that already exists)."""
+        database.init_db()
+        with database.get_db() as db:
+            db.execute("DROP TABLE feeds CASCADE")
+            db.execute("""
+                CREATE TABLE feeds (
+                    id BIGSERIAL PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    url TEXT NOT NULL,
+                    feed_type TEXT DEFAULT 'rss',
+                    poll_interval INTEGER DEFAULT 15,
+                    last_fetched TIMESTAMP,
+                    last_item_id TEXT,
+                    user_id BIGINT NOT NULL DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+        database.init_db()
+
+        with database.get_db() as db:
+            columns = {
+                c["column_name"]
+                for c in db.execute(
+                    "SELECT column_name FROM information_schema.columns"
+                    " WHERE table_name = 'feeds'"
+                ).fetchall()
+            }
+        for expected in ("lease_token", "lease_expires_at", "paused", "deleted_at"):
+            assert expected in columns, f"feeds.{expected} not backfilled on PG"
+
+    def test_echoes_legacy_columns_backfilled_on_pg(self, pg_env):
+        database.init_db()
+        with database.get_db() as db:
+            db.execute("DROP TABLE echoes CASCADE")
+            db.execute("""
+                CREATE TABLE echoes (
+                    id BIGSERIAL PRIMARY KEY,
+                    feed_id INTEGER NOT NULL,
+                    destination_type TEXT NOT NULL DEFAULT 'mastodon',
+                    destination_id INTEGER NOT NULL,
+                    template TEXT NOT NULL DEFAULT '{{ title }} {{ link }}',
+                    visibility TEXT DEFAULT 'public',
+                    enabled INTEGER DEFAULT 1,
+                    user_id BIGINT NOT NULL DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+        database.init_db()
+
+        with database.get_db() as db:
+            columns = {
+                c["column_name"]
+                for c in db.execute(
+                    "SELECT column_name FROM information_schema.columns"
+                    " WHERE table_name = 'echoes'"
+                ).fetchall()
+            }
+        for expected in (
+            "filter_keywords",
+            "filter_mode",
+            "content_warning",
+            "attach_image",
+            "delivery_mode",
+            "drip_limit",
+            "deleted_at",
+        ):
+            assert expected in columns, f"echoes.{expected} not backfilled on PG"
+
+    def test_posted_items_legacy_columns_backfilled_on_pg(self, pg_env):
+        database.init_db()
+        with database.get_db() as db:
+            db.execute("DROP TABLE posted_items")
+            db.execute("""
+                CREATE TABLE posted_items (
+                    id BIGSERIAL PRIMARY KEY,
+                    echo_id INTEGER NOT NULL,
+                    item_id TEXT NOT NULL,
+                    item_title TEXT,
+                    item_url TEXT,
+                    status TEXT NOT NULL,
+                    error_message TEXT,
+                    posted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+        database.init_db()
+
+        with database.get_db() as db:
+            columns = {
+                c["column_name"]
+                for c in db.execute(
+                    "SELECT column_name FROM information_schema.columns"
+                    " WHERE table_name = 'posted_items'"
+                ).fetchall()
+            }
+        for expected in (
+            "claimed_at",
+            "claim_token",
+            "post_url",
+            "attempt_count",
+            "next_retry_at",
+        ):
+            assert expected in columns, f"posted_items.{expected} not backfilled on PG"
+
+    def test_feeds_unique_index_rejects_duplicate_user_url(self, pg_env):
+        import psycopg
+
+        database.init_db()
+        with database.get_db() as db:
+            db.execute(
+                "INSERT INTO users (id, email, password_hash) VALUES (1, 'u@example.com', '')"
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id) VALUES ('Feed', 'https://x/feed', 1)"
+            )
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            with database.get_db() as db:
+                db.execute(
+                    "INSERT INTO feeds (name, url, user_id)"
+                    " VALUES ('Feed dup', 'https://x/feed', 1)"
+                )
+
+    def test_feeds_readd_after_soft_delete_allowed_on_pg(self, pg_env):
+        """The unique index is partial (WHERE deleted_at IS NULL): feeds are
+        soft-deleted and never purged, so re-adding the same URL after a
+        delete must not be permanently blocked."""
+        database.init_db()
+        with database.get_db() as db:
+            db.execute(
+                "INSERT INTO users (id, email, password_hash) VALUES (1, 'u@example.com', '')"
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id) VALUES ('Feed', 'https://x/feed', 1)"
+            )
+            db.execute(
+                "UPDATE feeds SET deleted_at = CURRENT_TIMESTAMP"
+                " WHERE url = 'https://x/feed' AND user_id = 1"
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id)"
+                " VALUES ('Feed again', 'https://x/feed', 1)"
+            )
+            rows = db.execute(
+                "SELECT * FROM feeds WHERE url = 'https://x/feed' AND user_id = 1"
+            ).fetchall()
+        assert len(rows) == 2
+
+    def test_accounts_unique_index_rejects_duplicate_user_instance_username(
+        self, pg_env
+    ):
+        import psycopg
+
+        database.init_db()
+        with database.get_db() as db:
+            db.execute(
+                "INSERT INTO users (id, email, password_hash) VALUES (1, 'u@example.com', '')"
+            )
+            db.execute(
+                "INSERT INTO accounts (name, username, instance, access_token, user_id)"
+                " VALUES ('Alice', 'alice', 'https://example.com', 'token', 1)"
+            )
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            with database.get_db() as db:
+                db.execute(
+                    "INSERT INTO accounts"
+                    " (name, username, instance, access_token, user_id)"
+                    " VALUES ('Alice again', 'alice', 'https://example.com',"
+                    " 'token2', 1)"
+                )
 
 
 @requires_pg
@@ -670,9 +895,18 @@ class TestPostgresTimestampReads:
         """posted_at must be app-generated UTC, comparable with _drip_rate's window.
 
         Postgres CURRENT_TIMESTAMP resolves in the session time zone, so it
-        silently skewed the drip window on any server not running UTC. The
-        database default is flipped here (get_db opens a new connection per
-        call, so a per-connection SET would not reach the code under test).
+        would silently skew the drip window on any server not running UTC.
+        This is now belt-and-suspenders: (1) posted_at is always bound
+        explicitly via _now() rather than left to a CURRENT_TIMESTAMP
+        default, and (2) _pg_connect pins every new connection's session
+        time zone to UTC immediately after connect. The database default is
+        flipped to a hostile non-UTC zone here to prove #2: even a
+        misconfigured server default cannot leak through the per-connection
+        pin (get_db opens a new connection per call, so a stray per-session
+        SET on this test's own connection would not reach the code under
+        test — only the database-level default does, which the pin then
+        overrides on every connection including this test's own follow-up
+        checks).
         """
         import scheduler
 
@@ -700,11 +934,18 @@ class TestPostgresTimestampReads:
         try:
             assert scheduler._update_post(1, "tok", "success") is True
             with database.get_db() as db:
+                # The connection-level pin wins over the hostile database
+                # default: every fresh connection is forced back to UTC, so
+                # this reads 'UTC' rather than the 'America/New_York' just
+                # set above. If this ever reads back "America/New_York",
+                # the connect-time pin (finding #5 / database._pg_connect)
+                # regressed.
                 assert db.execute(
                     "SELECT current_setting('TimeZone') AS tz"
-                ).fetchone()["tz"] == (
-                    "America/New_York"
-                ), "time zone override did not take effect; test would be vacuous"
+                ).fetchone()["tz"] == "UTC", (
+                    "connection-level UTC pin did not override the hostile"
+                    " database default; _pg_connect's SET TIME ZONE regressed"
+                )
                 stored = db.execute(
                     "SELECT posted_at FROM posted_items WHERE id = 1"
                 ).fetchone()["posted_at"]

--- a/tests/test_pg_dialect.py
+++ b/tests/test_pg_dialect.py
@@ -110,7 +110,7 @@ class TestPostgresInit:
 @requires_pg
 class TestPostgresSessionTimezone:
     def test_connection_pins_session_timezone_to_utc(self, pg_env):
-        """_pg_connect must SET TIME ZONE 'UTC' immediately after connect.
+        """_pg_connect must pin the session timezone to UTC at the handshake.
 
         Without this, CURRENT_TIMESTAMP/NOW() resolve in the server's
         session timezone rather than UTC, silently skewing every naive
@@ -121,6 +121,36 @@ class TestPostgresSessionTimezone:
         with database.get_db() as db:
             tz = db.execute("SELECT current_setting('TimeZone') AS tz").fetchone()["tz"]
         assert tz == "UTC"
+
+    def test_pg_connect_uses_handshake_options_not_post_connect_set(self, pg_env):
+        """The pin must happen at the connection handshake (options=), not
+        via a post-connect SET: psycopg3 wraps SET in an implicit
+        transaction, and a ROLLBACK on that connection reverts the session
+        timezone to the server default (verified: SET->rollback -> server
+        default). options= sets the parameter before any transaction exists
+        and cannot be reverted."""
+        import inspect
+
+        database.init_db()
+        src = inspect.getsource(database._pg_connect)
+        assert 'options="-c timezone=UTC"' in src
+        assert 'SET TIME ZONE' not in src
+        # Behavioral: fresh connection survives a rollback with the pin
+        # intact, against a server whose default timezone is NOT UTC.
+        conn = database._pg_connect()
+        try:
+            assert conn.execute("SHOW timezone").fetchone()[
+                "TimeZone"
+            ] == "UTC"
+            conn.rollback()
+            assert conn.execute("SHOW timezone").fetchone()[
+                "TimeZone"
+            ] == "UTC", (
+                "session timezone reverted after rollback: the pin was"
+                " applied inside a transaction instead of the handshake"
+            )
+        finally:
+            conn.close()
 
 
 @requires_pg
@@ -521,6 +551,91 @@ class TestPostgresMigration:
                     " VALUES ('Alice again', 'alice', 'https://example.com',"
                     " 'token2', 1)"
                 )
+
+    def test_init_db_survives_duplicate_rows_and_dedupes_on_pg(self, pg_env):
+        """Same upgrade-path guarantee as the sqlite suite: a legacy database
+        with duplicate accounts (plain-INSERT oauth_callback) and duplicate
+        active feeds must dedupe BEFORE the unique indexes are built, or the
+        upgrade crashes at boot."""
+        database.init_db()
+        with database.get_db() as db:
+            db.execute("DROP INDEX IF EXISTS idx_feeds_user_url")
+            db.execute("DROP INDEX IF EXISTS idx_accounts_user_instance_username")
+            db.execute(
+                "INSERT INTO accounts (name, username, instance, access_token, user_id)"
+                " VALUES ('Alice', 'alice', 'https://ex.com', 'old-token', 1)"
+            )
+            db.execute(
+                "INSERT INTO accounts (name, username, instance, access_token, user_id)"
+                " VALUES ('Alice new', 'alice', 'https://ex.com', 'new-token', 1)"
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id)"
+                " VALUES ('F', 'https://ex.com/rss', 1)"
+            )
+            db.execute(
+                "INSERT INTO feeds (name, url, user_id)"
+                " VALUES ('F2', 'https://ex.com/rss', 1)"
+            )
+            feed_ids = [
+                r["id"] for r in db.execute(
+                    "SELECT id FROM feeds ORDER BY id"
+                ).fetchall()
+            ]
+            keep_feed_id, old_feed_id = feed_ids[0], feed_ids[1]
+            acct_ids = [
+                r["id"] for r in db.execute(
+                    "SELECT id FROM accounts ORDER BY id"
+                ).fetchall()
+            ]
+            # Accounts keep MAX(id) (freshest reconnect = second insert);
+            # feeds keep MIN(id) (original = first insert).
+            keep_acct_id, old_acct_id = acct_ids[1], acct_ids[0]
+            db.execute(
+                "INSERT INTO echoes (feed_id, destination_type, destination_id,"
+                " template, user_id) VALUES (?, 'mastodon', ?, 't', 1)",
+                (old_feed_id, old_acct_id),
+            )
+            db.execute(
+                "INSERT INTO feed_items (feed_id, item_id, title)"
+                " VALUES (?, 'i1', 'A')",
+                (keep_feed_id,),
+            )
+            db.execute(
+                "INSERT INTO feed_items (feed_id, item_id, title)"
+                " VALUES (?, 'i2', 'keep')",
+                (old_feed_id,),
+            )
+
+        # Pre-fix, this raised UniqueViolation from CREATE UNIQUE INDEX.
+        database.init_db()
+
+        with database.get_db() as db:
+            accounts = db.execute(
+                "SELECT id, access_token FROM accounts"
+            ).fetchall()
+            assert len(accounts) == 1
+            # MAX(id) survives: the freshest reconnect wins.
+            assert accounts[0]["access_token"] == "new-token"
+            assert accounts[0]["id"] == keep_acct_id
+            echo = db.execute(
+                "SELECT destination_id FROM echoes"
+            ).fetchone()
+            # The echo must follow the surviving account.
+            assert echo["destination_id"] == keep_acct_id
+            active = db.execute(
+                "SELECT id, deleted_at FROM feeds ORDER BY id"
+            ).fetchall()
+            assert len(active) == 2
+            assert active[0]["deleted_at"] is None
+            assert active[1]["deleted_at"] is not None
+            items = db.execute(
+                "SELECT feed_id, item_id FROM feed_items ORDER BY item_id"
+            ).fetchall()
+            assert [(r["feed_id"], r["item_id"]) for r in items] == [
+                (keep_feed_id, "i1"),
+                (keep_feed_id, "i2"),
+            ]
 
 
 @requires_pg
@@ -934,7 +1049,7 @@ class TestPostgresTimestampReads:
         try:
             assert scheduler._update_post(1, "tok", "success") is True
             with database.get_db() as db:
-                # The connection-level pin wins over the hostile database
+                # The handshake-level pin wins over the hostile database
                 # default: every fresh connection is forced back to UTC, so
                 # this reads 'UTC' rather than the 'America/New_York' just
                 # set above. If this ever reads back "America/New_York",
@@ -944,7 +1059,8 @@ class TestPostgresTimestampReads:
                     "SELECT current_setting('TimeZone') AS tz"
                 ).fetchone()["tz"] == "UTC", (
                     "connection-level UTC pin did not override the hostile"
-                    " database default; _pg_connect's SET TIME ZONE regressed"
+                    " database default; the handshake timezone option"
+                    " regressed"
                 )
                 stored = db.execute(
                     "SELECT posted_at FROM posted_items WHERE id = 1"

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -228,6 +228,54 @@ class TestFeedCapRoute:
             row = db.execute("SELECT poll_interval FROM feeds").fetchone()
         assert row["poll_interval"] == 1  # no plan clamp in single mode
 
+    def test_readd_existing_url_at_cap_updates_instead_of_402(self, multi_client):
+        """The feed INSERT is an upsert: re-adding an existing URL adds zero
+        rows, so the plan cap must not block it (it previously 402'd)."""
+        self._fill_feeds(multi_client, 5)
+        r = multi_client.post(
+            "/api/feeds",
+            data={"name": "renamed", "url": "https://example.com/feed0.xml"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        with database.get_db() as db:
+            rows = db.execute(
+                "SELECT name FROM feeds WHERE url = 'https://example.com/feed0.xml'"
+                " AND user_id = ?",
+                (UID,),
+            ).fetchall()
+        assert len(rows) == 1  # upserted, not duplicated
+        assert rows[0]["name"] == "renamed"
+
+    def test_readd_soft_deleted_url_creates_new_row_and_hits_cap_check(
+        self, multi_client
+    ):
+        """A soft-deleted URL sits outside the partial unique index, so
+        re-adding it creates a NEW active row: it must go through the cap
+        check as a new feed (here it succeeds because the delete freed a
+        slot), and the result is two rows for one URL, one deleted."""
+        self._fill_feeds(multi_client, 5)
+        with database.get_db() as db:
+            db.execute(
+                "UPDATE feeds SET deleted_at = '2026-01-01 00:00:00'"
+                " WHERE user_id = ? AND url = 'https://example.com/feed0.xml'",
+                (UID,),
+            )
+        r = multi_client.post(
+            "/api/feeds",
+            data={"name": "resurrected", "url": "https://example.com/feed0.xml"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        with database.get_db() as db:
+            rows = db.execute(
+                "SELECT deleted_at FROM feeds"
+                " WHERE url = 'https://example.com/feed0.xml' AND user_id = ?",
+                (UID,),
+            ).fetchall()
+        assert len(rows) == 2
+        assert sum(1 for x in rows if x["deleted_at"] is None) == 1
+
 class TestDestinationCapRoute:
     def test_add_destination_blocked_at_cap(self, multi_client):
         for i in range(5):
@@ -245,6 +293,68 @@ class TestDestinationCapRoute:
         )
         assert r.status_code == 200
         assert "5 connected" in r.text
+
+    def test_readd_existing_mastodon_account_at_cap_updates_instead_of_402(
+        self, multi_client, monkeypatch
+    ):
+        """The accounts INSERT is an upsert: re-adding an existing
+        (user, instance, username) account adds zero rows, so the
+        destination cap must not block a reconnect (it previously 402'd)."""
+        monkeypatch.setattr("app.validate_url", lambda u: u)
+        r = multi_client.post(
+            "/api/accounts",
+            data={"name": "A", "username": "alice",
+                  "instance": "https://m.example", "access_token": "tok1"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        # Fill the rest of the cap: 1 account + 4 emails = 5 total.
+        for i in range(4):
+            multi_client.post(
+                "/api/email-accounts",
+                data={"name": f"a{i}", "email": f"user{i}@example.com"},
+                follow_redirects=False,
+            )
+        # Reconnect the SAME account: must succeed and update, not 402.
+        r = multi_client.post(
+            "/api/accounts",
+            data={"name": "A2", "username": "alice",
+                  "instance": "https://m.example", "access_token": "tok2"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        with database.get_db() as db:
+            rows = db.execute(
+                "SELECT id, name, access_token FROM accounts"
+                " WHERE user_id = ? AND username = 'alice'",
+                (UID,),
+            ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["name"] == "A2"
+        assert rows[0]["access_token"] == "tok2"
+
+    def test_new_mastodon_account_at_cap_still_402s(self, multi_client, monkeypatch):
+        """The cap gate must still fire for genuinely new accounts."""
+        monkeypatch.setattr("app.validate_url", lambda u: u)
+        for i in range(5):
+            multi_client.post(
+                "/api/email-accounts",
+                data={"name": f"a{i}", "email": f"user{i}@example.com"},
+                follow_redirects=False,
+            )
+        r = multi_client.post(
+            "/api/accounts",
+            data={"name": "B", "username": "bob",
+                  "instance": "https://m.example", "access_token": "tok"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 200
+        assert "5 connected" in r.text
+        with database.get_db() as db:
+            count = db.execute(
+                "SELECT COUNT(*) AS c FROM accounts WHERE username = 'bob'"
+            ).fetchone()["c"]
+        assert count == 0
 
     def test_cap_counts_across_destination_types(self, multi_client):
         # 4 email + 1 microblog = 5 total → next email is blocked

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -149,7 +149,10 @@ class TestFeedCapRoute:
         for i in range(n):
             r = client.post(
                 "/api/feeds",
-                data={"name": f"f{i}", "url": "https://example.com/feed.xml"},
+                # Distinct per-iteration URLs: feeds now have a UNIQUE(user_id,
+                # url) index, so identical URLs would collapse into a single
+                # upserted row instead of counting toward the plan cap.
+                data={"name": f"f{i}", "url": f"https://example.com/feed{i}.xml"},
                 follow_redirects=False,
             )
             assert r.status_code == 303

--- a/tests/test_reader_tier2.py
+++ b/tests/test_reader_tier2.py
@@ -103,6 +103,47 @@ class TestOpml:
         assert '<outline text="Tech">' in text
         assert 'xmlUrl="https://example.com/ars.xml"' in text
 
+    def test_import_concurrent_duplicate_url_counts_as_duplicate_not_500(
+        self, env, monkeypatch
+    ):
+        """A duplicate that appears BETWEEN the route's existence snapshot
+        and its INSERT (import racing a manual add, or a second import) must
+        be counted via the unique index as 'duplicate', not raise a bare
+        IntegrityError (500). The index only exists because this import used
+        to dedupe with check-then-insert alone."""
+        import app as app_module
+
+        real_validate = app_module.validate_url
+
+        def validate_and_race(url):
+            validated = real_validate(url)
+            if validated == "https://example.com/raced.xml":
+                # Simulate the concurrent insert: we are inside the import's
+                # outline loop, after its SELECT-snapshot of existing urls.
+                with database.get_db() as db2:
+                    db2.execute(
+                        "INSERT INTO feeds (name, url, user_id)"
+                        " VALUES ('Racer', 'https://example.com/raced.xml', 1)"
+                    )
+            return validated
+
+        monkeypatch.setattr(app_module, "validate_url", validate_and_race)
+        opml = (
+            '<?xml version="1.0"?><opml version="2.0"><body>'
+            '<outline text="Raced" xmlUrl="https://example.com/raced.xml"/>'
+            "</body></opml>"
+        )
+        with TestClient(app) as c:
+            r = c.post("/api/feeds/opml", data={"opml": opml}, follow_redirects=False)
+        assert r.status_code == 303
+        assert "duplicate=1" in r.headers["location"]
+        assert "imported=0" in r.headers["location"]
+        with database.get_db() as db:
+            rows = db.execute(
+                "SELECT id FROM feeds WHERE url = 'https://example.com/raced.xml'"
+            ).fetchall()
+        assert len(rows) == 1  # only the concurrent row survives
+
     def test_import_oversize_upload_rejected(self, env):
         oversize = b"a" * (2_000_001)
         with TestClient(app) as c:

--- a/tests/test_template_preview.py
+++ b/tests/test_template_preview.py
@@ -35,11 +35,12 @@ def _seed_feed(name="Example Feed", url="https://example.com/feed.xml"):
         return cursor.lastrowid
 
 
-def _seed_account():
+def _seed_account(username="test"):
     with get_db() as db:
         cursor = db.execute(
             "INSERT INTO accounts (name, username, instance, access_token)"
-            " VALUES ('Test', 'test', 'https://example.com', 'tok')"
+            " VALUES ('Test', ?, 'https://example.com', 'tok')",
+            (username,),
         )
         return cursor.lastrowid
 
@@ -232,7 +233,7 @@ class TestEchoFormValidation:
     def test_edit_echo_rejects_bad_template(self, client):
         feed_id = _seed_feed()
         echo_id = _seed_echo(feed_id)
-        account_id = _seed_account()
+        account_id = _seed_account(username="test2")
         form = self._mastodon_form(feed_id, account_id, "{% if summary %}broken")
         form["echo_id"] = str(echo_id)
         resp = client.post(


### PR DESCRIPTION
## Summary
- `accounts.username` had a SQLite backfill migration (`ALTER TABLE` + regex backfill from `name`) but no Postgres equivalent — `CREATE TABLE IF NOT EXISTS` is a no-op on an existing table, so any pre-existing hosted Postgres database would crash the moment `accounts.username` was touched. Added the same `_add_column_if_missing` + backfill to `init_db_postgres`, plus the same treatment for `feeds` (`lease_token`/`lease_expires_at`/`paused`/`deleted_at`), `echoes` (`filter_keywords`/`filter_mode`/`content_warning`/`attach_image`/`delivery_mode`/`drip_limit`/`deleted_at`), and `posted_items` (`claimed_at`/`claim_token`/`post_url`/`attempt_count`/`next_retry_at`) — columns SQLite already backfills that Postgres never did.
- Postgres's `CURRENT_TIMESTAMP`/`NOW()` resolve in the session/server timezone before being cast into naive `TIMESTAMP` columns, unlike SQLite's `CURRENT_TIMESTAMP` which is always UTC — silently skewing every stored timestamp against `as_utc_naive()`/`timestamp_str()`'s UTC assumption on a non-UTC Postgres server. Pinned the session timezone to UTC immediately after connecting (`SET TIME ZONE 'UTC'`).
- `feeds` and `accounts` had no DB-level UNIQUE constraint backing `import_export.py`'s check-then-insert dedup, unlike every other destination table — a race (two concurrent imports, or an import racing a manual add) could create duplicate rows. Added `CREATE UNIQUE INDEX IF NOT EXISTS` (applies retroactively to existing installs without a risky table-rebuild migration) on `feeds(user_id, url) WHERE deleted_at IS NULL` (partial: feeds are soft-deleted, never purged) and `accounts(user_id, instance, username)`, for both SQLite and Postgres. Updated `add_account`/`add_feed`/`oauth_callback` in `app.py` to `ON CONFLICT ... DO UPDATE` so existing reconnect/re-add flows keep working under the new constraint instead of raising an integrity error.

Fixes `docs/reviews/2026-09-09-bug-review.md` findings #4, #5, #18, #19.

## Test plan
- `FEEDECHO_MODE=single pytest -m "not pg and not multi" -q` → 1467 passed, 1 skipped, no regressions.
- `FEEDECHO_MODE=multi pytest -m multi -q` → 82 passed, no regressions.
- **No live Postgres is available in this sandbox** to execute the Postgres-path changes against directly — they were validated by close reading and matching `init_db_postgres`'s existing style. The `pg`-marked test suite (`test_pg_dialect.py`, `test_reader_pg.py`, etc.) will run for real against a live Postgres in CI's `postgres` job on this PR — **please watch that job closely**.
- Updated two pre-existing tests (`test_plans.py`, `test_template_preview.py`) that relied on being able to insert duplicate feed URLs / duplicate account usernames, which the new UNIQUE indexes now correctly reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ

## Review gate (Gemini 3.8 Flash, post-push)

First-round gate findings, all triaged against source and fixed (commits bcc03f5, 514b4a0, 44bbd8e, 8a1aa2b):

- **HIGH — boot crash on upgraded databases.** `CREATE UNIQUE INDEX` ran against rows created by the pre-PR unguarded INSERTs (`oauth_callback` re-connected via plain INSERT, so duplicate `(user_id, instance, username)` account rows are expected in the wild). Reproduced pre-fix: legacy-shaped DB + PR init → `IntegrityError` at import time, app unbootable. **Fix:** `init_db` now dedupes before index creation in both dialects — accounts keep `MAX(id)` (freshest token), `echoes`/`queued_posts` references repointed, older rows deleted; feeds keep `MIN(id)`, `feed_items` merged (colliding `item_id`s dropped, rest repointed), duplicates soft-deleted so `posted_items` history survives. Pinned by sqlite + PG tests proven RED pre-fix.
- **HIGH — plan caps blocked upserts.** `add_account`/`add_feed`/`oauth_callback` checked the cap unconditionally, so a user at quota could not reconnect an existing account or re-save an existing feed (the upsert adds zero rows). **Fix:** cap fires only when the natural-key row is absent (mirrors `add_email_account`). Re-add after soft-delete still counts as new. Route tests added, RED pre-fix.
- **HIGH — import INSERTs could 500 on the new index.** `import_opml` and `import_export.import_data` were still bare INSERTs; a duplicate appearing between the dedup SELECT and the INSERT (the exact race the index exists to police) raised a bare `IntegrityError`. **Fix:** `ON CONFLICT DO NOTHING` + survivor lookup, lost race mapped onto the surviving row (`duplicate += 1` in OPML). Race-window tests added, RED pre-fix.
- **MEDIUM — TZ pin reverted on rollback.** A post-connect `SET TIME ZONE 'UTC'` runs inside psycopg3's implicit transaction; a ROLLBACK reverts it to the server default (empirically confirmed). **Fix:** pin moved to the handshake, `psycopg.connect(..., options="-c timezone=UTC")` — not revertible, no extra round trip. Docstring-only tests updated; behavioral rollback test added, RED pre-fix.

Second gate (fix delta only) pending; CI re-running on the pushed head.

**Corrections to the original summary above:** all "missing" Postgres columns were already present in the PG schema twin when the dialect layer shipped (e7109b9, which is the origin of every Postgres database in existence), so the parity `ALTER`s are no-ops on real installs and the `username`-backfill branch is dead code (kept for belt-and-suspenders, harmless); pre-fix prod Postgres had a UTC default anyway, so finding #5's live impact was limited to non-UTC servers.
