### PR TITLE
fix(destinations): classify Mastodon auth failures, fix Bluesky truncation limits, guard Matrix link truncation

### DIFF
--- a/bluesky.py
+++ b/bluesky.py
@@ -27,6 +27,11 @@ POST_COLLECTION = "app.bsky.feed.post"
 POST_RECORD_TYPE = "app.bsky.feed.post"
 
 MAX_POST_GRAPHEMES = 300
+# app.bsky.feed.post's `text` field caps at maxLength: 3000 UTF-8 bytes, a
+# second, independent limit from maxGraphemes above — a post can be under
+# 300 grapheme clusters and still be over 3000 bytes (e.g. ZWJ emoji
+# sequences, which pack many bytes into one cluster).
+MAX_POST_BYTES = 3000
 MAX_ALT_GRAPHEMES = 1000
 # Bluesky raised the app.bsky.embed.images limit 1 MB -> 2 MB in April 2026
 # (atproto PR #4823). Images above this are downscaled/re-encoded by
@@ -345,9 +350,57 @@ _VARIATION_SELECTORS = {"\ufe0e", "\ufe0f"}
 _SKIN_TONE_RANGE = range(0x1F3FB, 0x1F400)
 _EMOJI_TAG_RANGE = range(0xE0020, 0xE0080)
 
+# Python's unicodedata does not expose Extended_Pictographic (it is not a
+# general category), and the `regex` package that provides
+# \p{Extended_Pictographic} is not a project dependency (checked
+# requirements.txt / pyproject.toml). This is a range-based approximation
+# covering the Unicode blocks that hold the overwhelming majority of
+# real-world emoji, used only to gate GB11 below. It is NOT a complete
+# UAX #29 implementation: a few rare Extended_Pictographic code points
+# outside these ranges will be missed (under-glue -- same failure mode the
+# old code already had for other boundaries, harmless for the 300/3000
+# caps, just an occasional visually-split emoji), but ordinary letters,
+# digits, and punctuation are reliably excluded, which is what fixes the
+# bug this guards against.
+_EXTENDED_PICTOGRAPHIC_RANGES = (
+    (0x00A9, 0x00A9),    # copyright
+    (0x00AE, 0x00AE),    # registered
+    (0x203C, 0x203C),    # double exclamation
+    (0x2049, 0x2049),    # exclamation question
+    (0x2122, 0x2122),    # trademark
+    (0x2139, 0x2139),    # information
+    (0x2194, 0x21AA),    # arrows used as emoji
+    (0x231A, 0x231B),    # watch, hourglass
+    (0x2328, 0x2328),    # keyboard
+    (0x23CF, 0x23CF),
+    (0x23E9, 0x23FA),    # playback controls / clocks
+    (0x24C2, 0x24C2),
+    (0x25AA, 0x25FE),    # geometric shapes used as emoji
+    (0x2600, 0x27BF),    # misc symbols + dingbats (most classic emoji)
+    (0x2934, 0x2935),
+    (0x2B00, 0x2BFF),    # misc symbols and arrows (stars, etc.)
+    (0x3030, 0x3030),
+    (0x303D, 0x303D),
+    (0x3297, 0x3297),
+    (0x3299, 0x3299),
+    (0x1F000, 0x1FAFF),  # mahjong/dominoes through symbols & pictographs ext-A
+    (0x1FB00, 0x1FBFF),  # legacy computing symbols (some emoji-adjacent)
+)
+
 
 def _is_regional_indicator(ch: str) -> bool:
     return 0x1F1E6 <= ord(ch) <= 0x1F1FF
+
+
+def _is_extended_pictographic(ch: str) -> bool:
+    """Approximate check for Unicode's Extended_Pictographic property.
+
+    Restricts the ZWJ forward-glue (GB11) below to actual emoji
+    continuations -- see _EXTENDED_PICTOGRAPHIC_RANGES for why this is a
+    range-based stand-in rather than a full property lookup.
+    """
+    cp = ord(ch)
+    return any(lo <= cp <= hi for lo, hi in _EXTENDED_PICTOGRAPHIC_RANGES)
 
 
 def _trailing_ri_count(cluster: str) -> int:
@@ -365,11 +418,16 @@ def _grapheme_clusters(text: str) -> list[str]:
 
     A new grapheme starts at any character that is not a combining mark,
     zero-width joiner, variation selector, skin-tone modifier, or emoji tag
-    character. ZWJ glues in both directions (GB9 + a permissive GB11
-    stand-in), so ZWJ emoji sequences like family emoji stay together.
-    Regional-indicator pairs (flags) merge so a flag never splits. The
-    remaining gaps over-merge, which can only under-count graphemes, so
-    truncation never exceeds platform limits.
+    character. A ZWJ always glues to the cluster before it (GB9). A
+    character *after* a ZWJ only glues onto that cluster when it is itself
+    emoji/Extended_Pictographic (an approximation of GB11) -- a ZWJ used for
+    non-emoji purposes (e.g. some Indic-script ligatures) no longer swallows
+    whatever ordinary character happens to follow it. Regional-indicator
+    pairs (flags) merge so a flag never splits. The remaining gaps
+    over-merge, which can only under-count graphemes, so truncation never
+    exceeds platform limits (that reasoning does NOT extend to the ZWJ
+    forward-glue case, which is why it is now gated on Extended_Pictographic
+    instead of firing unconditionally).
     """
     clusters: list[str] = []
     for ch in text:
@@ -384,7 +442,10 @@ def _grapheme_clusters(text: str) -> list[str]:
             is_continuation = (
                 is_continuation
                 or ch == _ZWJ
-                or clusters[-1][-1] == _ZWJ
+                or (
+                    clusters[-1][-1] == _ZWJ
+                    and _is_extended_pictographic(ch)
+                )
                 or (
                     _is_regional_indicator(ch)
                     and _trailing_ri_count(clusters[-1]) == 1
@@ -397,17 +458,42 @@ def _grapheme_clusters(text: str) -> list[str]:
     return clusters
 
 
-def truncate_graphemes(text: str, max_graphemes: int = MAX_POST_GRAPHEMES) -> str:
-    """Truncate to max_graphemes grapheme clusters, appending an ellipsis."""
+def truncate_graphemes(
+    text: str,
+    max_graphemes: int = MAX_POST_GRAPHEMES,
+    max_bytes: int | None = None,
+) -> str:
+    """Truncate to max_graphemes grapheme clusters, appending an ellipsis.
+
+    When max_bytes is given, the result is also capped at that many UTF-8
+    bytes -- app.bsky.feed.post's `text` enforces maxGraphemes AND maxLength
+    (bytes) as two independent limits, and a handful of grapheme clusters
+    can still add up to well over 3000 bytes (e.g. dense ZWJ emoji
+    sequences). Byte truncation drops whole grapheme clusters from the end
+    rather than slicing raw bytes, so it never splits a UTF-8 multi-byte
+    sequence.
+    """
     clusters = _grapheme_clusters(text)
-    if len(clusters) <= max_graphemes:
+    fits_graphemes = len(clusters) <= max_graphemes
+    fits_bytes = max_bytes is None or len(text.encode("utf-8")) <= max_bytes
+    if fits_graphemes and fits_bytes:
         return text
-    head = "".join(clusters[: max_graphemes - 1]).rstrip()
-    # Don't leave a dangling ZWJ at the cut point — it renders as a broken
-    # sequence in most clients.
-    while head.endswith(_ZWJ):
-        head = head[:-1]
-    return head + "…"
+
+    def _assemble(n: int) -> str:
+        head = "".join(clusters[:n]).rstrip()
+        # Don't leave a dangling ZWJ at the cut point -- it renders as a
+        # broken sequence in most clients.
+        while head.endswith(_ZWJ):
+            head = head[:-1]
+        return head + "…"
+
+    n = min(max_graphemes - 1, len(clusters)) if not fits_graphemes else len(clusters)
+    result = _assemble(n)
+    if max_bytes is not None:
+        while n > 0 and len(result.encode("utf-8")) > max_bytes:
+            n -= 1
+            result = _assemble(n)
+    return result
 
 
 # ── Posts and images ─────────────────────────────────────────────────────────

--- a/mastodon.py
+++ b/mastodon.py
@@ -3,6 +3,33 @@
 import httpx
 from typing import Optional
 from feed_parser import pinned_request, validate_outbound_url
+from utils import DestinationAuthError, DestinationError
+
+
+class MastodonError(DestinationError):
+    """Base error for Mastodon API interactions."""
+
+
+class MastodonAuthError(MastodonError, DestinationAuthError):
+    """Access token rejected or insufficient permission (HTTP 401/403).
+
+    Permanent: retries cannot help until the user reconnects the account.
+    """
+
+
+def _raise_for_status(response) -> None:
+    """Raise MastodonAuthError on 401/403, otherwise the plain httpx error.
+
+    401/403 mean the stored token was revoked/expired or lacks the required
+    scope — permanent, not worth retrying. Every other 4xx/5xx (rate limits,
+    server errors, etc.) falls through to httpx's generic HTTPStatusError,
+    which callers already treat as transient/retryable.
+    """
+    if response.status_code in (401, 403):
+        raise MastodonAuthError(
+            f"Mastodon rejected the access token (HTTP {response.status_code})."
+        )
+    response.raise_for_status()
 
 
 def upload_media(
@@ -47,8 +74,14 @@ def upload_media(
         response = pinned_request(
             "POST", url, timeout=60, headers=headers, files=files, data=data
         )
-        response.raise_for_status()
+        _raise_for_status(response)
         return response.json()
+    except MastodonAuthError:
+        # Permanent: the caller (scheduler._send_mastodon) needs to
+        # distinguish this from the transient failures below, so let it
+        # propagate rather than folding it into the "None on failure"
+        # contract used for everything else here.
+        raise
     # ValueError covers a 200 with a non-JSON body (an instance behind an
     # HTML-returning proxy), which otherwise escaped the documented
     # "None on failure" contract and crashed the caller. SSRFError is a
@@ -81,7 +114,9 @@ def post_status(
         Dict with response data including 'id' and 'url' on success.
 
     Raises:
-        httpx.HTTPStatusError on API failure.
+        MastodonAuthError on a rejected/expired token (HTTP 401/403) —
+        permanent, not worth retrying. httpx.HTTPStatusError on any other
+        API failure (rate limits, server errors, etc.) — transient.
     """
     instance = instance.rstrip("/")
     validate_outbound_url(instance)
@@ -101,7 +136,7 @@ def post_status(
     response = pinned_request(
         "POST", url, timeout=30, headers=headers, data=data
     )
-    response.raise_for_status()
+    _raise_for_status(response)
     return response.json()
 
 
@@ -109,6 +144,10 @@ def verify_credentials(instance: str, access_token: str) -> dict:
     """Verify credentials and return account info.
 
     Returns dict with 'username', 'display_name', 'url' on success.
+
+    Raises:
+        MastodonAuthError on a rejected/expired token (HTTP 401/403).
+        httpx.HTTPStatusError on any other API failure.
     """
     instance = instance.rstrip("/")
     validate_outbound_url(instance)
@@ -116,7 +155,7 @@ def verify_credentials(instance: str, access_token: str) -> dict:
     headers = {"Authorization": f"Bearer {access_token}"}
 
     response = pinned_request("GET", url, timeout=30, headers=headers)
-    response.raise_for_status()
+    _raise_for_status(response)
     return response.json()
 
 
@@ -125,6 +164,8 @@ def test_connection(instance: str, access_token: str) -> tuple[bool, str]:
     try:
         result = verify_credentials(instance, access_token)
         return True, f"Connected as @{result.get('username', 'unknown')}"
+    except MastodonAuthError as e:
+        return False, str(e)
     except httpx.HTTPStatusError as e:
         return False, f"HTTP {e.response.status_code}: {e.response.text[:200]}"
     except httpx.RequestError as e:

--- a/matrix.py
+++ b/matrix.py
@@ -201,6 +201,22 @@ def permalink(room_id: str, event_id: str) -> str:
     return f"https://matrix.to/#/{quote(room_id, safe='')}/{quote(event_id, safe='')}"
 
 
+def _link_or_plain(match: re.Match) -> str:
+    """Wrap a matched URL in an ``<a>`` tag, unless it looks truncated.
+
+    ``_truncate_body`` cuts on a plain character count and appends an
+    ellipsis with no URL awareness, so a long link can be sliced in half
+    with "…" glued directly onto what's left. The URL regex still matches
+    that partial string, and wrapping it in an anchor would ship a dead/
+    garbled link. Mirrors bluesky.build_facets' truncation guard: if the
+    truncation ellipsis landed inside the match, leave it as plain text.
+    """
+    uri = match.group(0)
+    if "…" in uri:
+        return uri
+    return f'<a href="{uri}">{uri}</a>'
+
+
 def html_body(text: str) -> str:
     """HTML for ``formatted_body``: escaped text with http(s) URLs linkified.
 
@@ -210,9 +226,7 @@ def html_body(text: str) -> str:
     ``&amp;`` inside the href, which is the correct HTML spelling of it.
     """
     escaped = html.escape(text, quote=False)
-    linked = _URL_RE.sub(
-        lambda m: f'<a href="{m.group(0)}">{m.group(0)}</a>', escaped
-    )
+    linked = _URL_RE.sub(_link_or_plain, escaped)
     return linked.replace("\n", "<br />")
 
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -26,10 +26,11 @@ from feed_parser import (
     truncate,
 )
 from filters import is_filtered, match_reason
-from mastodon import post_status, upload_media
+from mastodon import MastodonAuthError, MastodonError, post_status, upload_media
 from bluesky import (
     BLUESKY_IMAGE_TYPES,
     MAX_BLOB_BYTES,
+    MAX_POST_BYTES,
     MAX_POST_GRAPHEMES,
     BlueskyAuthError,
     BlueskyError,
@@ -1267,13 +1268,26 @@ def _send_mastodon(
             # Feed-provided alt text wins (the author wrote it); AI
             # generation is the fallback when the feed has none.
             description = _resolve_alt_text(echo, item, entry["alt"], img_bytes, img_type)
-            uploaded = upload_media(
-                instance=account["instance"],
-                access_token=decrypt_secret(account["access_token"]),
-                image_bytes=img_bytes,
-                content_type=img_type,
-                description=description,
-            )
+            try:
+                uploaded = upload_media(
+                    instance=account["instance"],
+                    access_token=decrypt_secret(account["access_token"]),
+                    image_bytes=img_bytes,
+                    content_type=img_type,
+                    description=description,
+                )
+            except MastodonAuthError:
+                # Permanent (revoked/expired token): every remaining image
+                # upload would fail the same way, and the post_status call
+                # below will raise the same error and get caught there,
+                # marking the post permanently failed — no need to duplicate
+                # that here, just stop trying to attach images.
+                logger.warning(
+                    "Echo %s: Mastodon token rejected during image upload for item %s",
+                    echo["id"],
+                    item["id"],
+                )
+                break
             if uploaded and uploaded.get("id"):
                 media_ids.append(str(uploaded["id"]))
                 logger.info(
@@ -1313,8 +1327,21 @@ def _send_mastodon(
             spoiler_text=cw_text,
             media_ids=media_ids or None,
         )
-    except Exception:
+    except MastodonAuthError as e:
+        # Token rejected: retries cannot help until the user reconnects.
+        logger.error("Echo %s: Mastodon token rejected: %s", echo["id"], e)
+        return _fail_post(
+            posted_id,
+            claim_token,
+            echo["id"],
+            f"Mastodon token rejected: {e}",
+            permanent=True,
+        )
+    except MastodonError as e:
         logger.exception("Echo %s: Mastodon post failed", echo["id"])
+        return _fail_post(posted_id, claim_token, echo["id"], f"Mastodon delivery failed: {e}")
+    except Exception:
+        logger.exception("Echo %s: Mastodon post failed unexpectedly", echo["id"])
         return _fail_post(posted_id, claim_token, echo["id"], "Mastodon delivery failed")
 
     # The API returns the canonical permalink; persisting it gives the
@@ -1496,7 +1523,9 @@ def _send_bluesky(
     # Content preparation is pure string work, but a bug here must not strand
     # the claimed row — finalize it as failed so the bounded retry owns it.
     try:
-        text = truncate_graphemes(content or "", MAX_POST_GRAPHEMES)
+        text = truncate_graphemes(
+            content or "", MAX_POST_GRAPHEMES, max_bytes=MAX_POST_BYTES
+        )
         facets = build_facets(text)
     except Exception:
         logger.exception("Echo %s: Bluesky content preparation failed", echo["id"])

--- a/scheduler.py
+++ b/scheduler.py
@@ -9,6 +9,7 @@ import threading
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 
+import httpx
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
@@ -1282,18 +1283,30 @@ def _send_mastodon(
                     content_type=img_type,
                     description=description,
                 )
-            except MastodonAuthError:
-                # Permanent (revoked/expired token): every remaining image
-                # upload would fail the same way, and the post_status call
-                # below will raise the same error and get caught there,
-                # marking the post permanently failed — no need to duplicate
-                # that here, just stop trying to attach images.
-                logger.warning(
-                    "Echo %s: Mastodon token rejected during image upload for item %s",
+            except MastodonAuthError as e:
+                # Permanent (revoked/expired token, or a token that can post
+                # but lacks the media scope): finalize the post as
+                # permanently failed right here. Falling through to
+                # post_status would silently publish text-only whenever the
+                # token can post but not upload media, and would route a
+                # pure 401 into the transient-retry path whenever
+                # post_status hit an unrelated transient failure.
+                # _fail_post fences on the claim token, so a lease lost
+                # during the image I/O no-ops here exactly as it does on
+                # every other failure path.
+                logger.error(
+                    "Echo %s: Mastodon token rejected during image upload for item %s: %s",
                     echo["id"],
                     item["id"],
+                    e,
                 )
-                break
+                return _fail_post(
+                    posted_id,
+                    claim_token,
+                    echo["id"],
+                    f"Mastodon token rejected: {e}",
+                    permanent=True,
+                )
             if uploaded and uploaded.get("id"):
                 media_ids.append(str(uploaded["id"]))
                 logger.info(
@@ -1347,7 +1360,11 @@ def _send_mastodon(
             f"Mastodon token rejected: {e}",
             permanent=True,
         )
-    except MastodonError as e:
+    except (MastodonError, httpx.HTTPStatusError) as e:
+        # _raise_for_status delegates every non-auth HTTP failure to
+        # httpx's HTTPStatusError, so catch it here rather than in the
+        # generic handler — the API's own error text belongs in the row's
+        # error_message, not a flat "delivery failed".
         logger.exception("Echo %s: Mastodon post failed", echo["id"])
         return _fail_post(posted_id, claim_token, echo["id"], f"Mastodon delivery failed: {e}")
     except Exception:

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -169,14 +169,87 @@ class TestTruncateGraphemes:
             c in "\U0001F1E9\U0001F1EA" for c in body
         )
 
-    def test_truncate_zwj_sequence_never_split(self):
+    def test_truncate_zwj_emoji_sequence_never_split(self):
         from bluesky import truncate_graphemes
 
-        # clusters: [a, b, c\u200dd, e, f] — the ZWJ cluster is atomic.
-        text = "abc\u200Ddef"
-        assert truncate_graphemes(text, 4) == "abc\u200Dd…"
+        # "woman technologist": WOMAN + ZWJ + LAPTOP is one atomic cluster
+        # because LAPTOP is Extended_Pictographic (GB11 applies).
+        # clusters: [a, b, <zwj-emoji>, e, f]
+        emoji = "\U0001F469\u200D\U0001F4BB"
+        text = "ab" + emoji + "ef"
+        assert truncate_graphemes(text, 4) == "ab" + emoji + "…"
         # Cutting before the ZWJ cluster drops it whole, never splits it.
         assert truncate_graphemes(text, 3) == "ab…"
+
+    def test_zwj_non_emoji_not_glued_forward(self):
+        """Finding #10 (bug review): GB11 must not fire for a non-emoji
+        character following a ZWJ. A ZWJ used outside an emoji sequence
+        (e.g. some Indic-script ligatures) must not swallow whatever
+        ordinary character follows it into one cluster -- doing so
+        under-counts true grapheme clusters, which can let a post through
+        the 300-grapheme cap that actually has more true clusters than
+        that.
+        """
+        from bluesky import _grapheme_clusters, truncate_graphemes
+
+        # "c" + ZWJ glues onto "c" (GB9 -- ZWJ always attaches backward),
+        # but "d" is plain ASCII, not Extended_Pictographic, so it must
+        # start a new cluster instead of being glued in by the old
+        # unconditional GB11 stand-in.
+        text = "c\u200Dd"
+        clusters = _grapheme_clusters(text)
+        assert len(clusters) == 2
+        assert clusters == ["c\u200D", "d"]
+
+        # With the old (buggy) unconditional glue this whole string counted
+        # as ONE grapheme and truncate_graphemes(text, 1) would return it
+        # unchanged; now it's two, so a max_graphemes=1 cap must truncate.
+        assert len(truncate_graphemes(text, 1)) < len(text)
+
+    def test_byte_cap_enforced_with_few_graphemes(self):
+        """Finding #10 (bug review): app.bsky.feed.post's `text` caps at
+        BOTH maxGraphemes: 300 AND maxLength: 3000 (UTF-8 bytes) -- two
+        independent limits. A string can be well under the grapheme cap
+        and still exceed the byte cap (e.g. many multi-codepoint ZWJ emoji
+        sequences, each one grapheme cluster but tens of bytes).
+        """
+        from bluesky import MAX_POST_BYTES, truncate_graphemes
+
+        # "woman technologist": WOMAN + ZWJ + LAPTOP -- 3 codepoints, ~14
+        # bytes, one grapheme cluster.
+        emoji = "\U0001F469‍\U0001F4BB"
+        text = emoji * 290  # 290 grapheme clusters (< 300), well over 3000 bytes
+        assert len(text.encode("utf-8")) > MAX_POST_BYTES
+
+        result = truncate_graphemes(text, 300, max_bytes=MAX_POST_BYTES)
+        assert len(result.encode("utf-8")) <= MAX_POST_BYTES
+        # Byte-safe: the result must still be valid UTF-8 (no split
+        # multi-byte sequence) and end on a whole grapheme cluster / the
+        # ellipsis, never a torn emoji.
+        assert result.encode("utf-8").decode("utf-8") == result
+        assert result.endswith("…")
+
+    def test_byte_cap_truncates_a_single_oversized_cluster(self):
+        """A single grapheme cluster that alone exceeds the byte cap (e.g.
+        a base character with an excessive combining-mark tail) must still
+        be trimmed rather than shipped whole and over budget -- dropping
+        the whole cluster and falling back to just the ellipsis is the
+        safest byte-safe behavior available at cluster granularity.
+        """
+        from bluesky import MAX_POST_BYTES, truncate_graphemes
+
+        text = "A" + "́" * 2000  # one grapheme cluster, ~4000 bytes
+        result = truncate_graphemes(text, 300, max_bytes=MAX_POST_BYTES)
+        assert len(result.encode("utf-8")) <= MAX_POST_BYTES
+
+    def test_byte_cap_not_enforced_when_omitted(self):
+        """max_bytes defaults to None (backward compatible) -- callers that
+        don't pass it, like the alt-text truncation, are unaffected."""
+        from bluesky import truncate_graphemes
+
+        text = "A" + "́" * 2000
+        result = truncate_graphemes(text, 300)
+        assert result == text
 
 # ── Facets ───────────────────────────────────────────────────────────────────
 

--- a/tests/test_cw_and_images.py
+++ b/tests/test_cw_and_images.py
@@ -647,6 +647,8 @@ class TestMastodonPostStatusParams:
         captured = {}
 
         class FakeResponse:
+            status_code = 200
+
             def raise_for_status(self):
                 pass
 
@@ -673,6 +675,8 @@ class TestMastodonPostStatusParams:
         captured = {}
 
         class FakeResponse:
+            status_code = 200
+
             def raise_for_status(self):
                 pass
 
@@ -697,6 +701,8 @@ class TestMastodonPostStatusParams:
         captured = {}
 
         class FakeResponse:
+            status_code = 200
+
             def raise_for_status(self):
                 pass
 
@@ -723,6 +729,7 @@ class TestMastodonPostStatusParams:
 
         class FakeResponse:
             fetch_status = None
+            status_code = 200
 
             def raise_for_status(self):
                 pass
@@ -746,6 +753,8 @@ class TestMastodonUploadMedia:
         import mastodon
 
         class FakeResponse:
+            status_code = 200
+
             def raise_for_status(self):
                 pass
 

--- a/tests/test_mastodon_post_url.py
+++ b/tests/test_mastodon_post_url.py
@@ -157,6 +157,15 @@ class TestMastodonAuthErrorIsPermanent:
         assert status == "failed"
         assert post_url is None
 
+        # The (MastodonError, httpx.HTTPStatusError) branch must record the
+        # API's own failure text, not the flat generic string the old
+        # `except Exception:` fallback produced.
+        with get_db() as db:
+            row = db.execute(
+                "SELECT error_message FROM posted_items WHERE echo_id = 1"
+            ).fetchone()
+        assert row["error_message"] == "Mastodon delivery failed: server error"
+
     def test_upload_media_auth_error_fails_the_post_permanently(self, db_tmp, monkeypatch, setup_echo):
         """A token rejected at IMAGE UPLOAD time must finalize the post as
         permanently failed right there, not fall through to post_status.

--- a/tests/test_mastodon_post_url.py
+++ b/tests/test_mastodon_post_url.py
@@ -102,6 +102,61 @@ class TestMastodonPostUrlStored:
         assert status == "failed"
         assert post_url is None
 
+
+class TestMastodonAuthErrorIsPermanent:
+    """Bug review finding #3: a 401/403 from Mastodon (revoked/expired
+    token) must be classified permanent -- marked 'gave_up' immediately
+    instead of scheduled for a retry that can never succeed, mirroring how
+    Bluesky/Matrix/micro.blog already handle their auth errors.
+    """
+
+    def test_401_marks_the_post_permanently_failed(self, db_tmp, monkeypatch, setup_echo):
+        from mastodon import MastodonAuthError
+
+        def boom(**kw):
+            raise MastodonAuthError("Mastodon rejected the access token (HTTP 401).")
+
+        monkeypatch.setattr(scheduler, "post_status", boom)
+        echo = setup_echo(attach_image=0)
+        assert scheduler.process_echo(echo, _item()) is True  # gave_up counts as "handled"
+
+        status, post_url = _post_url_for()
+        assert status == "gave_up"
+        assert post_url is None
+
+    def test_403_marks_the_post_permanently_failed(self, db_tmp, monkeypatch, setup_echo):
+        from mastodon import MastodonAuthError
+
+        def boom(**kw):
+            raise MastodonAuthError("Mastodon rejected the access token (HTTP 403).")
+
+        monkeypatch.setattr(scheduler, "post_status", boom)
+        echo = setup_echo(attach_image=0)
+        assert scheduler.process_echo(echo, _item()) is True
+
+        status, post_url = _post_url_for()
+        assert status == "gave_up"
+        assert post_url is None
+
+    def test_generic_httpx_error_still_scheduled_for_retry(self, db_tmp, monkeypatch, setup_echo):
+        # Contrast case: a non-auth HTTPStatusError (e.g. 500/429) must NOT
+        # be treated as permanent -- it stays in the ordinary bounded-retry
+        # path ('failed', not 'gave_up').
+        import httpx
+
+        def boom(**kw):
+            request = httpx.Request("POST", "https://mastodon.example/api/v1/statuses")
+            response = httpx.Response(503, request=request)
+            raise httpx.HTTPStatusError("server error", request=request, response=response)
+
+        monkeypatch.setattr(scheduler, "post_status", boom)
+        echo = setup_echo(attach_image=0)
+        assert scheduler.process_echo(echo, _item()) is False
+
+        status, post_url = _post_url_for()
+        assert status == "failed"
+        assert post_url is None
+
 # ── rendering ────────────────────────────────────────────────────────────────
 
 TENANT_ID = 21

--- a/tests/test_mastodon_post_url.py
+++ b/tests/test_mastodon_post_url.py
@@ -157,6 +157,95 @@ class TestMastodonAuthErrorIsPermanent:
         assert status == "failed"
         assert post_url is None
 
+    def test_upload_media_auth_error_fails_the_post_permanently(self, db_tmp, monkeypatch, setup_echo):
+        """A token rejected at IMAGE UPLOAD time must finalize the post as
+        permanently failed right there, not fall through to post_status.
+
+        Falling through has two holes: a token that can post but lacks the
+        media scope (403 on upload only) would silently publish text-only
+        and mark the row successful forever, and a pure 401 followed by an
+        unrelated transient post_status failure would enter the bounded
+        retry path even though every retry is doomed.
+        """
+        from mastodon import MastodonAuthError
+
+        post_calls = []
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"img-bytes", "image/jpeg")
+        )
+
+        def upload_boom(**kw):
+            raise MastodonAuthError("Mastodon rejected the access token (HTTP 401).")
+
+        monkeypatch.setattr(scheduler, "upload_media", upload_boom)
+        monkeypatch.setattr(
+            scheduler, "post_status", lambda **kw: post_calls.append(kw) or {"id": "1"}
+        )
+        echo = setup_echo(attach_image=1)
+        assert (
+            scheduler.process_echo(echo, _item(image_url="https://example.com/pic.jpg"))
+            is True
+        )
+
+        # The post must never be attempted, text-only or otherwise.
+        assert post_calls == []
+
+        with get_db() as db:
+            row = db.execute(
+                "SELECT status, error_message FROM posted_items WHERE echo_id = 1"
+            ).fetchone()
+        assert row["status"] == "gave_up"
+        assert row["error_message"].startswith("Mastodon token rejected:")
+
+    def test_upload_media_auth_error_after_a_successful_image_sends_nothing(
+        self, db_tmp, monkeypatch, setup_echo
+    ):
+        """Image 1 uploads, image 2 hits the rejected token: the post must
+        not go out with partial media either."""
+        from mastodon import MastodonAuthError
+
+        post_calls = []
+        upload_calls = []
+
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"img-bytes", "image/jpeg")
+        )
+
+        def upload(**kw):
+            upload_calls.append(kw)
+            if len(upload_calls) == 1:
+                return {"id": "m1"}
+            raise MastodonAuthError("Mastodon rejected the access token (HTTP 403).")
+
+        monkeypatch.setattr(scheduler, "upload_media", upload)
+        monkeypatch.setattr(
+            scheduler, "post_status", lambda **kw: post_calls.append(kw) or {"id": "1"}
+        )
+        echo = setup_echo(attach_image=1)
+        assert (
+            scheduler.process_echo(
+                echo,
+                _item(
+                    image_urls=[
+                        "https://example.com/1.jpg",
+                        "https://example.com/2.jpg",
+                        "https://example.com/3.jpg",
+                    ]
+                ),
+            )
+            is True
+        )
+
+        # Two uploads attempted (the second raised); image 3 never tried.
+        assert len(upload_calls) == 2
+        assert post_calls == []  # never posted with partial media
+
+        with get_db() as db:
+            row = db.execute(
+                "SELECT status FROM posted_items WHERE echo_id = 1"
+            ).fetchone()
+        assert row["status"] == "gave_up"
+
 # ── rendering ────────────────────────────────────────────────────────────────
 
 TENANT_ID = 21

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -365,6 +365,43 @@ class TestSendMessage:
         with pytest.raises(matrix.MatrixError):
             matrix.send_message("https://matrix.org", "tok", "!room:example.org", "   ", "txn-1")
 
+    def test_truncated_mid_url_not_linkified(self):
+        """Finding #24 (bug review): _truncate_body cuts on a plain char
+        count with no URL awareness, so a long trailing link can be sliced
+        in half with the ellipsis glued onto what's left. html_body must
+        not wrap that partial string in a dead/garbled <a href>.
+        """
+        with mock.patch.object(matrix, "pinned_request") as req:
+            req.return_value = _resp({"event_id": "$evt:example.org"})
+            long_url = "https://example.com/" + ("a" * 40000)
+            matrix.send_message(
+                "https://matrix.org", "tok", "!room:example.org",
+                f"Check this out: {long_url}", "txn-1",
+            )
+        _, kwargs = req.call_args
+        body = kwargs["json"]
+        # The plain body is truncated and ends with the ellipsis marker.
+        assert body["body"].endswith("…")
+        # The formatted body must not contain an anchor wrapping the
+        # truncated (now-invalid) URL.
+        assert "<a href=\"https://example.com/a" not in body["formatted_body"]
+        # It should still render as inert plain text, ellipsis and all.
+        assert body["formatted_body"].endswith("…")
+
+class TestHtmlBody:
+    def test_full_url_is_linkified(self):
+        html = matrix.html_body("See https://example.com/post now")
+        assert '<a href="https://example.com/post">https://example.com/post</a>' in html
+
+    def test_url_with_truncation_ellipsis_left_as_plain_text(self):
+        # Simulates the output of _truncate_body cutting mid-URL: the
+        # ellipsis lands directly after the partial URL with no separating
+        # whitespace, so the URL regex still matches it as one "URL".
+        text = "See https://example.com/really-long-path-that-got-cut…"
+        html = matrix.html_body(text)
+        assert "<a href" not in html
+        assert "https://example.com/really-long-path-that-got-cut…" in html
+
 class TestTransactionId:
     def test_deterministic(self):
         assert matrix.transaction_id(1, "item-1") == matrix.transaction_id(1, "item-1")


### PR DESCRIPTION
## Summary
- `mastodon.py` had no permanent/transient error classification — every 4xx/5xx surfaced as the same generic `httpx.HTTPStatusError`, so a revoked/expired token (401/403) got retried with backoff exactly like a rate limit or server error, even though retrying can never fix it. Added `MastodonAuthError` (raised specifically on 401/403), reusing the shared `DestinationError` hierarchy from `utils.py` the other destination modules already use. `scheduler._send_mastodon` now marks the post permanently failed on this error instead of retrying forever.
- `bluesky.py`'s `truncate_graphemes` only enforced the 300-grapheme cap; `app.bsky.feed.post`'s `text` field independently caps at 3000 UTF-8 bytes too (dense ZWJ sequences can be well under 300 clusters yet over 3000 bytes). Added byte-cap enforcement, plus restricted the ZWJ forward-glue rule (previously unconditional, so ordinary non-emoji text using a ZWJ was under-counted into fewer true clusters than it has) to fire only when the following character is emoji/Extended_Pictographic — a documented range-based approximation, not a full UAX#29 implementation (Python's `unicodedata` doesn't expose that property and `regex` isn't a project dependency).
- `matrix.py`'s `html_body` linkified whatever URL regex match remained after truncation cut it in half, producing a dead/garbled link. Added a guard (mirroring `bluesky.build_facets'`) that leaves a truncated match as plain text.
- Fixed 5 pre-existing tests in `tests/test_cw_and_images.py` whose `FakeResponse` mocks didn't define `status_code`, which the new `_raise_for_status` now checks first.

Fixes `docs/reviews/2026-09-09-bug-review.md` findings #3, #10, #24.

## Test plan
- `FEEDECHO_MODE=single pytest -m "not pg and not multi" -q` → 1472 passed, 1 skipped, no regressions.
- Extended `tests/test_mastodon_post_url.py`, `tests/test_bluesky.py`, `tests/test_matrix.py` covering the auth-error classification, byte-cap truncation, ZWJ non-emoji clustering, and the matrix truncated-link guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ