### PR TITLE
fix(auth): enforce STATE_SECRET in multi-mode; fix verification-token issuance race

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           FEEDECHO_MODE: multi
           FEEDECHO_SESSION_SECRET: ci-session-secret-0123456789abcdef0123456789abcdef
+          FEEDECHO_STATE_SECRET: ci-state-secret-0123456789abcdef0123456789abcdef
         run: pytest -m multi
 
   postgres:

--- a/oauth.py
+++ b/oauth.py
@@ -14,7 +14,6 @@ import settings
 from database import get_db
 from feed_parser import SSRFError, pinned_request, validate_outbound_url
 from security import decrypt_secret, encrypt_secret
-from settings import AUTH_TOKEN, STATE_SECRET
 
 SCOPES = "read write"
 STATE_TTL_SECONDS = 10 * 60
@@ -24,10 +23,28 @@ STATE_TTL_SECONDS = 10 * 60
 # silently shipping two different links.
 FALLBACK_WEBSITE = "https://github.com/jcrabapple/feedecho"
 
-# STATE_SECRET wins: in multi mode a carried-over single-mode AUTH_TOKEN must
-# never silently key OAuth-state HMACs (mirrors security.session_secret()'s
-# gate, which exists for exactly this scenario).
-_STATE_SECRET = (STATE_SECRET or AUTH_TOKEN or secrets.token_urlsafe(32)).encode("utf-8")
+# A random-per-process fallback used only in single mode (OAuth state is a
+# same-process CSRF token there; nothing depends on it surviving a restart).
+_RANDOM_FALLBACK_SECRET = secrets.token_urlsafe(32).encode("utf-8")
+
+
+def _state_secret() -> bytes:
+    """The HMAC key for OAuth state signatures.
+
+    Multi mode requires FEEDECHO_STATE_SECRET explicitly — mirrors
+    security.session_secret()'s gate, which exists for exactly this
+    scenario: a carried-over single-mode FEEDECHO_AUTH_TOKEN must never
+    silently key OAuth-state HMACs (it has no minimum-length requirement,
+    unlike FEEDECHO_SESSION_SECRET). Single mode falls back to AUTH_TOKEN,
+    then a random per-process value (OAuth state there is a same-process
+    CSRF token, not shared across restarts).
+    """
+    if settings.MULTI and not settings.STATE_SECRET:
+        raise RuntimeError(
+            "FEEDECHO_STATE_SECRET must be set when FEEDECHO_MODE=multi"
+        )
+    key = settings.STATE_SECRET or settings.AUTH_TOKEN
+    return key.encode("utf-8") if key else _RANDOM_FALLBACK_SECRET
 
 
 def _now() -> datetime:
@@ -45,7 +62,7 @@ def _hash_session_binding(session_binding: str) -> str:
 
 def _state_signature(nonce: str, instance: str) -> str:
     payload = f"{nonce}|{instance}".encode("utf-8")
-    return hmac.new(_STATE_SECRET, payload, hashlib.sha256).hexdigest()
+    return hmac.new(_state_secret(), payload, hashlib.sha256).hexdigest()
 
 
 def _sign_state(

--- a/settings.py
+++ b/settings.py
@@ -292,6 +292,19 @@ def validate_config() -> None:
         raise RuntimeError(
             "FEEDECHO_SESSION_SECRET must be at least 32 characters in multi mode"
         )
+    if not STATE_SECRET:
+        # Without this, oauth._state_secret() would otherwise need to fall
+        # back to FEEDECHO_AUTH_TOKEN (a carried-over single-mode value with
+        # no minimum-length requirement) to key OAuth-state HMACs — that
+        # fallback is itself gated to raise, but only at first OAuth use;
+        # catching it here fails loudly at startup instead.
+        raise RuntimeError(
+            "FEEDECHO_STATE_SECRET must be set when FEEDECHO_MODE=multi"
+        )
+    if len(STATE_SECRET) < 32:
+        raise RuntimeError(
+            "FEEDECHO_STATE_SECRET must be at least 32 characters in multi mode"
+        )
     if not BASE_URL:
         # Deliberately a warning, not a raise: unlike DATABASE_URL and
         # SESSION_SECRET, an unset BASE_URL degrades one feature (the links in

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -13,6 +13,7 @@ class TestAboutPage:
     def multi_env(self, monkeypatch, tmp_path):
         monkeypatch.setattr(settings, "MULTI", True)
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(settings, "AUTH_TOKEN", None)
         monkeypatch.setattr(settings, "DATABASE_URL", "")
         monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -15,6 +15,7 @@ from app import _account_deletion_hooks, app
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_accounts_sections.py
+++ b/tests/test_accounts_sections.py
@@ -17,6 +17,7 @@ def multi_client(monkeypatch, db_tmp):
     """Signed-in multi-mode TestClient over the temp DB."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_admin_dashboard.py
+++ b/tests/test_admin_dashboard.py
@@ -17,6 +17,7 @@ USER_ID = 11
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)
@@ -216,6 +217,7 @@ class TestAdminBootstrap:
     def test_admin_email_env_promotes_on_startup(self, monkeypatch, tmp_path):
         monkeypatch.setattr(settings, "MULTI", True)
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(settings, "AUTH_TOKEN", None)
         monkeypatch.setattr(settings, "DATABASE_URL", "")
         monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)
@@ -234,6 +236,7 @@ class TestAdminBootstrap:
     def test_bootstrap_is_idempotent_and_ignores_other_users(self, monkeypatch, tmp_path):
         monkeypatch.setattr(settings, "MULTI", True)
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(settings, "AUTH_TOKEN", None)
         monkeypatch.setattr(settings, "DATABASE_URL", "")
         monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_admin_delete_user.py
+++ b/tests/test_admin_delete_user.py
@@ -37,6 +37,7 @@ OTHER_ADMIN_ID = 12
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)
@@ -305,6 +306,7 @@ def pg_env(monkeypatch):
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", False)
     monkeypatch.setattr(settings, "CREDENTIAL_KEY", Fernet.generate_key().decode())
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     auth._login_attempts.clear()
     auth._register_attempts.clear()
     database.init_db()

--- a/tests/test_admin_email.py
+++ b/tests/test_admin_email.py
@@ -18,6 +18,7 @@ USER_ID = 11
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_admin_role.py
+++ b/tests/test_admin_role.py
@@ -27,6 +27,7 @@ class TestRegisterPath:
 
         monkeypatch.setattr(settings, "MULTI", True)
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(settings, "AUTH_TOKEN", None)
         monkeypatch.setattr(settings, "DATABASE_URL", "")
         monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_admin_usage.py
+++ b/tests/test_admin_usage.py
@@ -35,6 +35,7 @@ B_ID = 6
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_admin_xss_fix.py
+++ b/tests/test_admin_xss_fix.py
@@ -36,6 +36,7 @@ EVIL_EMAIL = "x'-alert(1)-'@a.co"
 def admin_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_auth_multi.py
+++ b/tests/test_auth_multi.py
@@ -14,6 +14,7 @@ def multi_env(monkeypatch, tmp_path):
     """Multi-mode environment on a fresh temp SQLite DB."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_credential_encryption.py
+++ b/tests/test_credential_encryption.py
@@ -101,6 +101,7 @@ class TestEncryptDecrypt:
         monkeypatch.setattr(s, "DATABASE_URL", "")
         monkeypatch.setattr(s, "ALLOW_SQLITE_FALLBACK", True)
         monkeypatch.setattr(s, "SESSION_SECRET", "s" * 40)
+        monkeypatch.setattr(s, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(s, "CREDENTIAL_KEY", "not-a-valid-fernet-key")
         with pytest.raises(RuntimeError, match="not a valid Fernet key"):
             s.validate_config()

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -472,6 +472,7 @@ def multi_client(monkeypatch, db_tmp):
     """Signed-in multi-mode TestClient over the temp DB."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_echo_editor_dest_types.py
+++ b/tests/test_echo_editor_dest_types.py
@@ -98,6 +98,7 @@ def multi_client(monkeypatch, db_tmp):
     """Signed-in multi-mode TestClient over the temp DB (mirrors test_discord.py)."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_email_verification.py
+++ b/tests/test_email_verification.py
@@ -17,6 +17,7 @@ UID = 5
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)
@@ -74,6 +75,64 @@ class TestTokenLifecycle:
         for _ in range(verification.RESEND_LIMIT):
             verification.issue_token(UID, "verify")
         assert verification.resend_allowed(UID, "verify") is False
+
+    def test_retry_on_conflict_consumes_not_deletes_concurrent_token(
+        self, multi_env, monkeypatch
+    ):
+        """A unique-violation on issuance (another issuer's row committed
+        between our UPDATE and INSERT) must not delete that row outright --
+        only the retry's own UPDATE may touch it, by consuming it. Deleting
+        it would silently invalidate an already-returned, possibly
+        already-emailed token instead of properly superseding it."""
+        import sqlite3
+        from contextlib import contextmanager
+
+        import security
+
+        concurrent = verification.issue_token(UID, "verify")
+
+        state = {"raised": False}
+
+        class _Proxy:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def execute(self, sql, params=()):
+                if not state["raised"] and "INSERT INTO email_tokens" in sql:
+                    state["raised"] = True
+                    raise sqlite3.IntegrityError(
+                        "UNIQUE constraint failed: simulated concurrent issuer"
+                    )
+                return self._conn.execute(sql, params)
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+        real_get_db = database.get_db
+
+        @contextmanager
+        def _wrapped_get_db():
+            with real_get_db() as conn:
+                yield _Proxy(conn)
+
+        monkeypatch.setattr(verification, "get_db", _wrapped_get_db)
+
+        new = verification.issue_token(UID, "verify")
+
+        assert state["raised"] is True
+        assert new != concurrent
+
+        with database.get_db() as db:
+            row = db.execute(
+                "SELECT consumed_at FROM email_tokens WHERE token_hash = ?",
+                (security.token_hash(concurrent),),
+            ).fetchone()
+        # Still a real row -- superseded (consumed), not vanished.
+        assert row is not None
+        assert row["consumed_at"] is not None
+
+        # The retried issuance itself is unaffected and fully usable.
+        assert verification.consume_token(new, "verify") == UID
 
 
 class TestVerifyEndpoint:

--- a/tests/test_howto.py
+++ b/tests/test_howto.py
@@ -17,6 +17,7 @@ class TestHowToPage:
     def env(self, monkeypatch, tmp_path):
         monkeypatch.setattr(settings, "MULTI", True)
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(settings, "AUTH_TOKEN", None)
         monkeypatch.setattr(settings, "DATABASE_URL", "")
         monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -28,6 +28,7 @@ def multi_env(monkeypatch, db_tmp):
     """Multi mode, invites REQUIRED, admin + regular user rows."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_kimi_full_review_fixes.py
+++ b/tests/test_kimi_full_review_fixes.py
@@ -30,6 +30,7 @@ def multi_client(monkeypatch, db_tmp):
 
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)
@@ -580,11 +581,13 @@ class TestOauthStateSecretPrecedence:
         })
         import oauth
 
-        assert oauth._STATE_SECRET == b"state-secret-value"
+        assert oauth._state_secret() == b"state-secret-value"
 
     def test_auth_token_still_fallback_without_state_secret(
         self, monkeypatch, restore_oauth,
     ):
+        # Single mode only: the multi-mode case (no silent AUTH_TOKEN
+        # fallback) is covered by TestStateSecretMultiModeGate below.
         self._reload(monkeypatch, {
             "FEEDECHO_MODE": "single",
             "FEEDECHO_AUTH_TOKEN": "auth-token-value",
@@ -592,4 +595,29 @@ class TestOauthStateSecretPrecedence:
         })
         import oauth
 
-        assert oauth._STATE_SECRET == b"auth-token-value"
+        assert oauth._state_secret() == b"auth-token-value"
+
+
+class TestStateSecretMultiModeGate:
+    """In multi mode, _state_secret() must never silently fall back to
+    AUTH_TOKEN — mirrors security.session_secret()'s gate for exactly the
+    same reason: a carried-over single-mode AUTH_TOKEN has no minimum-length
+    requirement and must not silently key OAuth-state HMACs."""
+
+    def test_raises_without_state_secret_even_with_auth_token(
+        self, monkeypatch,
+    ):
+        import oauth
+
+        monkeypatch.setattr(settings, "MULTI", True)
+        monkeypatch.setattr(settings, "STATE_SECRET", "")
+        monkeypatch.setattr(settings, "AUTH_TOKEN", "auth-token-value")
+        with pytest.raises(RuntimeError, match="FEEDECHO_STATE_SECRET"):
+            oauth._state_secret()
+
+    def test_succeeds_with_state_secret_set(self, monkeypatch):
+        import oauth
+
+        monkeypatch.setattr(settings, "MULTI", True)
+        monkeypatch.setattr(settings, "STATE_SECRET", "state-secret-value")
+        assert oauth._state_secret() == b"state-secret-value"

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -26,6 +26,7 @@ UID = 5
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_legal_pages.py
+++ b/tests/test_legal_pages.py
@@ -26,6 +26,7 @@ UID = 5
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_mastodon_post_url.py
+++ b/tests/test_mastodon_post_url.py
@@ -110,6 +110,7 @@ TENANT_ID = 21
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -536,6 +536,7 @@ def multi_client(monkeypatch, db_tmp):
     """Signed-in multi-mode TestClient over the temp DB."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_microblog.py
+++ b/tests/test_microblog.py
@@ -402,6 +402,7 @@ def multi_client(monkeypatch, db_tmp):
     """Signed-in multi-mode TestClient over the temp DB."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_nav_gating.py
+++ b/tests/test_nav_gating.py
@@ -148,6 +148,7 @@ SUSPENDED_ID = 13
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -19,6 +19,7 @@ UID = 5
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_pending_card_gate.py
+++ b/tests/test_pending_card_gate.py
@@ -24,6 +24,7 @@ USER_ID = 222
 def _client(monkeypatch, tmp_path, *, billing, trial_ends_at, plan="trial"):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_pg_dialect.py
+++ b/tests/test_pg_dialect.py
@@ -312,6 +312,8 @@ class TestAppOnPostgres:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
         database.init_db()
@@ -334,6 +336,8 @@ class TestAppOnPostgres:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
         database.init_db()
@@ -361,6 +365,8 @@ class TestAppOnPostgres:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
         database.init_db()
@@ -411,6 +417,8 @@ class TestAppOnPostgres:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
         database.init_db()
@@ -464,6 +472,8 @@ class TestAppOnPostgres:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
         database.init_db()

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -28,6 +28,7 @@ def multi_client(monkeypatch, db_tmp):
     """Signed-in multi-mode TestClient over the temp DB."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -13,6 +13,7 @@ class TestPricingPage:
     def multi_env(self, monkeypatch, tmp_path):
         monkeypatch.setattr(settings, "MULTI", True)
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(settings, "AUTH_TOKEN", None)
         monkeypatch.setattr(settings, "DATABASE_URL", "")
         monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -15,6 +15,7 @@ from app import app, _next_free_slot
 def queue_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_queue_review_fixes.py
+++ b/tests/test_queue_review_fixes.py
@@ -17,6 +17,7 @@ import scheduler
 def fix_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_reader_compose.py
+++ b/tests/test_reader_compose.py
@@ -14,6 +14,7 @@ from app import app, DESTINATION_LIMITS
 def compose_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_reader_pg.py
+++ b/tests/test_reader_pg.py
@@ -107,6 +107,8 @@ class TestReaderStoragePg:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
@@ -161,6 +163,8 @@ class TestReaderPagePg:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         # The lifespan starts the scheduler; no-op its feed sweep so the
         # background thread does no DB work that could race monkeypatch
         # teardown (which flips the dialect back to sqlite mid-query).
@@ -198,6 +202,8 @@ class TestReaderTier2Pg:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
@@ -241,6 +247,8 @@ class TestReaderTier2Pg:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
@@ -298,6 +306,8 @@ class TestReaderTier2Pg:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
@@ -344,6 +354,8 @@ class TestReaderTier2Pg:
         from datetime import datetime, timedelta, timezone
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
@@ -403,6 +415,8 @@ class TestReaderTier2Pg:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()
@@ -447,6 +461,8 @@ class TestReaderTier2Pg:
         from app import app
 
         monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+
+        monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
         monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
         auth_mod._login_attempts.clear()
         auth_mod._register_attempts.clear()

--- a/tests/test_reader_plans.py
+++ b/tests/test_reader_plans.py
@@ -14,6 +14,7 @@ from app import app
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_reader_saved_searches.py
+++ b/tests/test_reader_saved_searches.py
@@ -16,6 +16,7 @@ def p5_env(monkeypatch, tmp_path):
     monkeypatch.setattr(database, "DB_PATH", db_file)
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
     database.init_db()
 

--- a/tests/test_reader_training.py
+++ b/tests/test_reader_training.py
@@ -17,6 +17,7 @@ def p4_env(monkeypatch, tmp_path):
     monkeypatch.setattr(database, "DB_PATH", db_file)
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "x" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "x" * 40)
     monkeypatch.setattr(scheduler, "check_all_feeds", lambda: None)
     database.init_db()
 

--- a/tests/test_reader_ui.py
+++ b/tests/test_reader_ui.py
@@ -103,6 +103,7 @@ class TestReaderPageSingle:
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_release_7.py
+++ b/tests/test_release_7.py
@@ -14,6 +14,7 @@ import settings
 def multi_client(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -182,9 +182,8 @@ class TestOAuthCallbackErrorPages:
 
         monkeypatch.setattr(app_module.settings, "MULTI", True)
         monkeypatch.setattr(app_module.settings, "AUTH_TOKEN", None)
-        monkeypatch.setattr(
-            app_module.settings, "SESSION_SECRET", "x" * 40
-        )
+        monkeypatch.setattr(app_module.settings, "SESSION_SECRET", "x" * 40)
+        monkeypatch.setattr(app_module.settings, "STATE_SECRET", "x" * 40)
         return TestClient(app_module.app)
 
     def test_denied_authorization_renders_an_error_page(self, multi_client):
@@ -395,6 +394,7 @@ class TestAltTextTenantScopingAndSsrf:
         monkeypatch.setattr(app_module.settings, "MULTI", True)
         monkeypatch.setattr(app_module.settings, "AUTH_TOKEN", None)
         monkeypatch.setattr(app_module.settings, "SESSION_SECRET", "y" * 40)
+        monkeypatch.setattr(app_module.settings, "STATE_SECRET", "y" * 40)
         return app_module, TestClient(app_module.app)
 
     def _configure_alt_text(self, user_id: int, base_url: str) -> None:

--- a/tests/test_scheduler_leases.py
+++ b/tests/test_scheduler_leases.py
@@ -19,6 +19,7 @@ requires_pg = pytest.mark.skipif(
 @pytest.fixture
 def env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(database, "DB_PATH", tmp_path / "sched.db")
     database.init_db()

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -19,6 +19,7 @@ A_ID, B_ID = 2, 3
 def env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -100,6 +100,13 @@ class TestValidateConfig:
         monkeypatch.setattr(
             settings, "SESSION_SECRET", kwargs.get("secret", "")
         )
+        # Defaults to a valid value: tests targeting a later check (e.g.
+        # CREDENTIAL_KEY) shouldn't also have to think about this one.
+        # Tests that specifically target the STATE_SECRET check pass
+        # state="" (or a short value) explicitly.
+        monkeypatch.setattr(
+            settings, "STATE_SECRET", kwargs.get("state", "s" * 32)
+        )
         monkeypatch.setattr(
             settings, "CREDENTIAL_KEY", kwargs.get("key", "")
         )
@@ -129,6 +136,26 @@ class TestValidateConfig:
     def test_multi_with_short_session_secret_raises(self, monkeypatch):
         self._set_multi(
             monkeypatch, url="postgresql://x/x", secret="short", key=_VALID_KEY
+        )
+        import pytest
+
+        with pytest.raises(RuntimeError, match="at least 32"):
+            settings.validate_config()
+
+    def test_multi_without_state_secret_raises(self, monkeypatch):
+        self._set_multi(
+            monkeypatch, url="postgresql://x/x", secret="s" * 32, state="",
+            key=_VALID_KEY,
+        )
+        import pytest
+
+        with pytest.raises(RuntimeError, match="FEEDECHO_STATE_SECRET"):
+            settings.validate_config()
+
+    def test_multi_with_short_state_secret_raises(self, monkeypatch):
+        self._set_multi(
+            monkeypatch, url="postgresql://x/x", secret="s" * 32,
+            state="short", key=_VALID_KEY,
         )
         import pytest
 

--- a/tests/test_shout.py
+++ b/tests/test_shout.py
@@ -103,6 +103,7 @@ class TestShout:
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_smtp_ssrf.py
+++ b/tests/test_smtp_ssrf.py
@@ -24,6 +24,7 @@ def multi_client(monkeypatch, tmp_path):
     monkeypatch.setattr(app_module.settings, "MULTI", True)
     monkeypatch.setattr(app_module.settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(app_module.settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(app_module.settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr("database.DB_PATH", str(tmp_path / "test.db"))
     monkeypatch.setattr(app_module, "_smtp_test_attempts", {})
     init_db()

--- a/tests/test_trial_limits_visibility.py
+++ b/tests/test_trial_limits_visibility.py
@@ -29,6 +29,7 @@ USER_ID = 111
 def _setup(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_ui_multi.py
+++ b/tests/test_ui_multi.py
@@ -19,6 +19,7 @@ A_ID = 2
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_ux_p1_fixes.py
+++ b/tests/test_ux_p1_fixes.py
@@ -38,6 +38,7 @@ def multi_env(monkeypatch, tmp_path):
     """/register is a multi-mode page; render it the way test_nav_gating does."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_ux_p2_fixes.py
+++ b/tests/test_ux_p2_fixes.py
@@ -57,6 +57,7 @@ def multi_env(monkeypatch, tmp_path):
     """/register, /accounts and /echoes are multi-mode pages."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_ux_p3_fixes.py
+++ b/tests/test_ux_p3_fixes.py
@@ -36,6 +36,7 @@ def _tpl(name: str) -> str:
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -177,6 +177,7 @@ ADMIN_ID = 8
 def multi_env(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -499,6 +499,7 @@ def multi_client(monkeypatch, db_tmp):
     """Signed-in multi-mode TestClient over the temp DB."""
     monkeypatch.setattr(settings, "MULTI", True)
     monkeypatch.setattr(settings, "SESSION_SECRET", "s" * 40)
+    monkeypatch.setattr(settings, "STATE_SECRET", "s" * 40)
     monkeypatch.setattr(settings, "AUTH_TOKEN", None)
     monkeypatch.setattr(settings, "DATABASE_URL", "")
     monkeypatch.setattr(settings, "ALLOW_SQLITE_FALLBACK", True)

--- a/verification.py
+++ b/verification.py
@@ -32,6 +32,7 @@ def issue_token(user_id: int, purpose: str) -> str:
     expires = (
         datetime.now(timezone.utc) + timedelta(hours=TOKEN_TTL_HOURS)
     ).strftime(_TS)
+    last_exc: Exception | None = None
     for _attempt in (1, 2):
         try:
             with get_db() as db:
@@ -52,14 +53,18 @@ def issue_token(user_id: int, purpose: str) -> str:
         except Exception as exc:  # noqa: BLE001
             if exc.__class__.__name__ not in ("IntegrityError", "UniqueViolation"):
                 raise
-            # Concurrent issuer won the race; clear the live row and retry.
-            with get_db() as db:
-                db.execute(
-                    "DELETE FROM email_tokens"
-                    " WHERE user_id = ? AND purpose = ? AND consumed_at IS NULL",
-                    (user_id, purpose),
-                )
-    raise RuntimeError("email token issuance failed after retry")
+            # A concurrent issuer's INSERT landed between our UPDATE and
+            # INSERT above, so ours collided with its still-live row on the
+            # partial unique index (one unconsumed token per user+purpose).
+            # get_db() rolled back both of our statements with this whole
+            # attempt, so there is nothing of ours to clean up — deleting
+            # "whatever row is currently live" here would delete that
+            # concurrent issuer's already-committed (and possibly
+            # already-emailed) token instead of anything we created.
+            # Simply retrying re-runs the UPDATE, which now correctly
+            # consumes that row itself, then our INSERT succeeds.
+            last_exc = exc
+    raise RuntimeError("email token issuance failed after retry") from last_exc
 
 
 def resend_allowed(user_id: int, purpose: str) -> bool:


### PR DESCRIPTION
## Summary
- `oauth.py`'s `_STATE_SECRET` fell back to `FEEDECHO_AUTH_TOKEN` (then a random value) whenever `FEEDECHO_STATE_SECRET` was unset, with **no gate on multi mode** — contradicting its own comment, which claimed this mirrors `security.session_secret()`'s explicit refusal to let a carried-over single-mode `AUTH_TOKEN` (no minimum-length requirement, unlike `SESSION_SECRET`) silently key multi-tenant secrets. Converted `_STATE_SECRET` into a lazily-evaluated `_state_secret()`, gated exactly like `session_secret()`: raises if `MULTI` and `STATE_SECRET` is unset. Added the same check (32-char minimum, matching `SESSION_SECRET`) to `settings.validate_config()`, so a misconfigured multi-mode deployment fails loudly at startup instead of silently at first OAuth use.
- **Deployment-affecting behavior change**: any multi-mode install without `FEEDECHO_STATE_SECRET` set will now fail to start. **Set it before upgrading** (`FEEDECHO_STATE_SECRET`, ≥32 characters).
- `verification.py`'s `issue_token` retried on a unique-violation (two concurrent issuers racing the partial "one unconsumed token per user+purpose" index) by **deleting** whatever row currently matched `consumed_at IS NULL` for that user+purpose. Since `get_db()` rolls back the whole failed attempt, the only live row left to match is the *other* issuer's already-committed, already-returned (and possibly already-emailed) token — deleting it silently invalidates a link the user is about to click. Removed the manual `DELETE` entirely: simply retrying re-runs the `UPDATE`, which correctly consumes that row itself (preserving it as an audit record for the resend throttle), before the `INSERT` succeeds.

Fixes `docs/reviews/2026-09-09-bug-review.md` findings #17, #25.

## Test plan
- `FEEDECHO_MODE=single pytest -m "not pg and not multi" -q` → 1467 passed, 1 skipped, no regressions.
- `FEEDECHO_MODE=multi FEEDECHO_SESSION_SECRET=... FEEDECHO_STATE_SECRET=... pytest -m multi -q` → 82 passed, no regressions.
- Updated the multi-mode CI job (`.github/workflows/tests.yml`) and ~44 test fixtures that configure multi mode to also set `STATE_SECRET` alongside the existing `SESSION_SECRET` convention — without this, the new startup check breaks every test that exercises multi mode.
- Added `TestStateSecretMultiModeGate` (`tests/test_kimi_full_review_fixes.py`) and two new cases in `tests/test_settings.py::TestValidateConfig` covering the new gate.
- Added `test_retry_on_conflict_consumes_not_deletes_concurrent_token` (`tests/test_email_verification.py`), which forces a unique-violation via a connection proxy and asserts the "concurrent" token survives as a consumed row rather than being deleted. **Verified this test fails against the pre-fix code** (confirmed the row is `None` — deleted — with `verification.py` reverted) before confirming it passes against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LapTivxokSXFPpvZfW9vUQ