### PR TITLE
fix(scheduler): orphan-sweep isolation, digest failure alerting, drip requeue on interrupted dispatch; reader badge restyle

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -2170,6 +2170,62 @@ def _queue_for_digest(
     return ok
 
 
+def _requeue_drip_release_error(
+    echo_id: int,
+    item_id: str,
+    item_json: str,
+    attempts: int,
+    posted_id: int,
+    exc: Exception,
+) -> None:
+    """Requeue a drip release whose dispatch raised an unexpected exception.
+
+    Unlike _requeue_drip_failure, which runs after a completed dispatch and
+    can rely on the row being 'failed', an escaped exception leaves the
+    posted row 'pending' under this worker's claim. Requeueing must
+    therefore clear that claim, and it must clear it in one transaction
+    with the drip_items insert: if the row were requeued but the insert
+    failed, the next flush would re-release the item and double-insert the
+    queue row; if the insert landed but the row stayed pending, the item
+    would sit unclaimable for the reclaim window while the queue row is
+    dead (the queue join only matches status 'queued').
+
+    'attempts' is deliberately NOT incremented here. This path is an
+    infrastructure fault, not a delivery failure; the flush's per-row
+    isolation logs the traceback, so a persistently faulting release shows
+    up loudly in the logs instead of silently exhausting the retry cap.
+    """
+    with get_db() as db:
+        result = db.execute(
+            """UPDATE posted_items
+                  SET status = 'queued',
+                      claimed_at = NULL,
+                      claim_token = NULL,
+                      next_retry_at = NULL,
+                      posted_at = ?
+                WHERE id = ? AND status = 'pending' AND claim_token IS NOT NULL""",
+            (_now(), posted_id),
+        )
+        if result.rowcount != 1:
+            # Someone else finalized the row (e.g. the ten minute reclaim
+            # sweep or a concurrent worker); their outcome owns it now.
+            return
+        db.execute(
+            """INSERT INTO drip_items (echo_id, item_id, item_json, attempts)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(echo_id, item_id) DO UPDATE SET attempts = excluded.attempts""",
+            (echo_id, item_id, item_json, attempts),
+        )
+    logger.error(
+        "Echo %s: drip release raised %s: %s; item %s requeued (attempt count held at %d)",
+        echo_id,
+        type(exc).__name__,
+        exc,
+        item_id,
+        attempts,
+    )
+
+
 def _requeue_drip_failure(
     echo_id: int,
     item_id: str,
@@ -2622,16 +2678,38 @@ def _flush_one_drip(row, discarded: set[int], released: dict[int, int]) -> None:
             return
 
         posted_id, claim_token = claimed
-        with get_db() as db:
-            db.execute("DELETE FROM drip_items WHERE id = ?", (row["drip_id"],))
-
         logger.info(
             "Echo %s: releasing dripped item %s (%d in window)",
             echo_id,
             row["item_id"],
             _drip_rate(echo_id),
         )
-        _render_and_dispatch(dict(row), item, row["feed_name"] or "", posted_id, claim_token)
+        try:
+            _render_and_dispatch(dict(row), item, row["feed_name"] or "", posted_id, claim_token)
+        except Exception as exc:
+            # _render_and_dispatch converts its own and the senders'
+            # failures into posted_items status changes; an exception
+            # escaping it is an infrastructure fault (DB error, a bug).
+            # The drip_items row has not been deleted yet at this point,
+            # so the item must be requeued explicitly — leaving it
+            # 'pending' after the claim would strand it until the ten
+            # minute reclaim sweep, which does not restore the queue row
+            # and would burn attempt_count. Retrying is the safe
+            # direction for an item queued for delivery: the send may
+            # not have been attempted, and the drip cap bounds how much
+            # a persistently faulting release can dump per window.
+            _requeue_drip_release_error(
+                echo_id,
+                row["item_id"],
+                row["item_json"],
+                row["attempts"],
+                posted_id,
+                exc,
+            )
+            return
+
+        with get_db() as db:
+            db.execute("DELETE FROM drip_items WHERE id = ?", (row["drip_id"],))
 
         if _row_state(echo_id, row["item_id"]) == "failed":
             _requeue_drip_failure(
@@ -2683,20 +2761,31 @@ def _discard_orphaned_digest_items() -> None:
 
     for row in orphans:
         echo_id = row["echo_id"]
-        reason = "Digest discarded: echo or destination is no longer active"
-        with get_db() as db:
-            db.execute(
-                """UPDATE posted_items
-                      SET status = 'gave_up',
-                          error_message = ?,
-                          claimed_at = NULL,
-                          claim_token = NULL,
-                          posted_at = ?
-                    WHERE echo_id = ? AND status = 'queued'""",
-                (reason, _now(), echo_id),
+        try:
+            reason = "Digest discarded: echo or destination is no longer active"
+            with get_db() as db:
+                db.execute(
+                    """UPDATE posted_items
+                          SET status = 'gave_up',
+                              error_message = ?,
+                              claimed_at = NULL,
+                              claim_token = NULL,
+                              posted_at = ?
+                        WHERE echo_id = ? AND status = 'queued'""",
+                    (reason, _now(), echo_id),
+                )
+                db.execute("DELETE FROM digest_items WHERE echo_id = ?", (echo_id,))
+            logger.info("Echo %s: %s", echo_id, reason)
+        except Exception:
+            # Isolate one orphan row's failure from the rest: this sweep
+            # runs before the per-echo loop in _flush_digests, so an
+            # unhandled exception here would abort the whole digest tick
+            # before any live tenant's digest was even queried — the same
+            # bug class the per-row isolation elsewhere guards against.
+            logger.exception(
+                "Digest orphan sweep: unhandled error for echo %s", echo_id
             )
-            db.execute("DELETE FROM digest_items WHERE echo_id = ?", (echo_id,))
-        logger.info("Echo %s: %s", echo_id, reason)
+            continue
 
 
 def flush_digests() -> None:
@@ -2753,19 +2842,24 @@ def _flush_digests() -> None:
             # data shape) must not skip every other tenant's pending digest
             # for the whole tick. Mirrors _flush_queue's per-row isolation.
             logger.exception("Digest flush: unhandled error for echo %s", echo_id)
+            # record_failure feeds the notify threshold, so a permanently
+            # broken echo (corrupt payload, persistent DB error) surfaces
+            # to the user instead of failing silently every tick. The
+            # send_email failure path in _flush_one_digest calls it too;
+            # only exceptions OUTSIDE that guard were silent before.
+            record_failure(echo_id)
             continue
 
 
-def _flush_one_digest(echo_id: int, echo_row) -> None:
-    with get_db() as db:
-        items = db.execute(
-            "SELECT * FROM digest_items WHERE echo_id = ? ORDER BY created_at ASC",
-            (echo_id,),
-        ).fetchall()
+def _build_digest_body(echo_row, items) -> tuple[str, str, list, list]:
+    """Assemble a digest email's subject/body from queued rows.
 
-    if not items:
-        return
-
+    Returns (subject, body, sent_items, held_items). Items that fit the
+    char cap go in the body; the rest are returned as held for the next
+    flush. Malformed rows raise, which the caller's per-echo isolation
+    contains. Extracted so tests can fault-inject body assembly (the step
+    the narrow send_email try/except never covered).
+    """
     # Build digest body incrementally so overflow can be detected
     # per-item: everything that fits goes out now, the rest stays
     # queued for the next flush. Silently truncating here reported
@@ -2808,6 +2902,27 @@ def _flush_one_digest(echo_id: int, echo_row) -> None:
             body_parts.append(f"   {first['rendered_content'][:budget]}…")
             sent_items.append(first)
 
+    body = "\n".join(body_parts)
+    if held_items:
+        body += (
+            f"\n\n[{len(held_items)} newer item{'s' if len(held_items) != 1 else ''}"
+            " held for the next digest to stay under the size cap.]"
+        )
+    return subject, body, sent_items, held_items
+
+
+def _flush_one_digest(echo_id: int, echo_row) -> None:
+    with get_db() as db:
+        items = db.execute(
+            "SELECT * FROM digest_items WHERE echo_id = ? ORDER BY created_at ASC",
+            (echo_id,),
+        ).fetchall()
+
+    if not items:
+        return
+
+    subject, body, sent_items, held_items = _build_digest_body(echo_row, items)
+
     if not sent_items:
         # Nothing fit this round (pathological content only): leave the
         # queue untouched rather than send an empty digest or drop the
@@ -2818,13 +2933,6 @@ def _flush_one_digest(echo_id: int, echo_row) -> None:
             DIGEST_MAX_CHARS,
         )
         return
-
-    body = "\n".join(body_parts)
-    if held_items:
-        body += (
-            f"\n\n[{len(held_items)} newer item{'s' if len(held_items) != 1 else ''}"
-            " held for the next digest to stay under the size cap.]"
-        )
 
     try:
         send_email(

--- a/scheduler.py
+++ b/scheduler.py
@@ -2176,6 +2176,7 @@ def _requeue_drip_release_error(
     item_json: str,
     attempts: int,
     posted_id: int,
+    claim_token: str,
     exc: Exception,
 ) -> None:
     """Requeue a drip release whose dispatch raised an unexpected exception.
@@ -2190,10 +2191,16 @@ def _requeue_drip_release_error(
     would sit unclaimable for the reclaim window while the queue row is
     dead (the queue join only matches status 'queued').
 
+    The UPDATE fences on THIS worker's claim_token, not just 'pending':
+    if the reclaim sweep re-claimed the row while the dispatch was stuck,
+    the token has changed and the new owner's claim must not be clobbered
+    (the queue row was never deleted on this path, so there is nothing to
+    restore either).
+
     'attempts' is deliberately NOT incremented here. This path is an
-    infrastructure fault, not a delivery failure; the flush's per-row
-    isolation logs the traceback, so a persistently faulting release shows
-    up loudly in the logs instead of silently exhausting the retry cap.
+    infrastructure fault, not a delivery failure; record_failure still
+    fires so a persistently faulting release reaches the notify threshold
+    instead of retrying silently every flush.
     """
     with get_db() as db:
         result = db.execute(
@@ -2203,12 +2210,12 @@ def _requeue_drip_release_error(
                       claim_token = NULL,
                       next_retry_at = NULL,
                       posted_at = ?
-                WHERE id = ? AND status = 'pending' AND claim_token IS NOT NULL""",
-            (_now(), posted_id),
+                WHERE id = ? AND status = 'pending' AND claim_token = ?""",
+            (_now(), posted_id, claim_token),
         )
         if result.rowcount != 1:
-            # Someone else finalized the row (e.g. the ten minute reclaim
-            # sweep or a concurrent worker); their outcome owns it now.
+            # The claim was lost (another worker or the reclaim sweep owns
+            # the row now); their outcome wins and the queue row survives.
             return
         db.execute(
             """INSERT INTO drip_items (echo_id, item_id, item_json, attempts)
@@ -2216,6 +2223,7 @@ def _requeue_drip_release_error(
                ON CONFLICT(echo_id, item_id) DO UPDATE SET attempts = excluded.attempts""",
             (echo_id, item_id, item_json, attempts),
         )
+    record_failure(echo_id)
     logger.error(
         "Echo %s: drip release raised %s: %s; item %s requeued (attempt count held at %d)",
         echo_id,
@@ -2704,6 +2712,7 @@ def _flush_one_drip(row, discarded: set[int], released: dict[int, int]) -> None:
                 row["item_json"],
                 row["attempts"],
                 posted_id,
+                claim_token,
                 exc,
             )
             return
@@ -2806,8 +2815,13 @@ def flush_digests() -> None:
 
 def _flush_digests() -> None:
     # Sweep first: stranded items are invisible to the query below, so nothing
-    # would ever clear them.
-    _discard_orphaned_digest_items()
+    # would ever clear them. The sweep itself is per-row isolated; wrapping
+    # the invocation too keeps an unexpected fault there from aborting the
+    # whole tick before any live tenant's digest is queried.
+    try:
+        _discard_orphaned_digest_items()
+    except Exception:
+        logger.exception("Digest orphan sweep: unhandled error before flush")
 
     with get_db() as db:
         # Find all echoes that have pending digest items

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1396,6 +1396,10 @@ details.account-section > summary:focus-visible {
 .reader-feed-meta { display: inline-flex; align-items: center; gap: 0.4rem; flex-shrink: 0; }
 .reader-feed-echo { color: var(--text-muted); font-size: 0.85rem; }
 .reader-feed-unread { background: var(--primary-wash); color: var(--primary); border-radius: 999px; min-width: 1.4rem; text-align: center; padding: 0 0.4rem; font-size: 0.75rem; font-weight: 600; line-height: 1.4; }
+/* Saved-search badges count TOTAL matches (the page shows read items too),
+   so they must not wear the unread pill styling — a permanent total styled
+   as an unread counter never clears and misleads. Muted outline instead. */
+.reader-search-count { background: transparent; color: var(--text-muted); border: 1px solid var(--border); border-radius: 999px; min-width: 1.4rem; text-align: center; padding: 0 0.4rem; font-size: 0.75rem; font-weight: 600; line-height: 1.3; }
 .reader-main { min-width: 0; }
 .reader-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 0.75rem; margin-bottom: 1rem; flex-wrap: wrap; }
 .reader-tabs { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f6f8">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/css/style.css?v=58">
+    <link rel="stylesheet" href="/static/css/style.css?v=59">
     <link rel="apple-touch-icon" href="/favicon.svg">
     <script>
     // Set theme before first paint to avoid flash. Three states stored in

--- a/templates/reader.html
+++ b/templates/reader.html
@@ -20,7 +20,7 @@
             <span class="reader-feed-name" title="{{ s.query }}">{{ s.name }}</span>
             <span class="reader-feed-meta">
               {% if saved_search_counts and saved_search_counts[s.id] %}
-              <span class="reader-feed-unread">{{ saved_search_counts[s.id] }}</span>
+              <span class="reader-search-count" title="{{ saved_search_counts[s.id] }} matching item{{ 's' if saved_search_counts[s.id] != 1 else '' }}">{{ saved_search_counts[s.id] }}</span>
               {% endif %}
             </span>
           </a>

--- a/tests/test_admin_mobile_actions.py
+++ b/tests/test_admin_mobile_actions.py
@@ -80,4 +80,4 @@ class TestAdminMobileActions:
 
     def test_cache_buster_bumped(self):
         base = (REPO_ROOT / "templates" / "base.html").read_text(encoding="utf-8")
-        assert 'style.css?v=58' in base
+        assert 'style.css?v=59' in base

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -504,3 +504,111 @@ class TestDigestFlush:
         with db_tmp.get_db() as db:
             rows = db.execute("SELECT * FROM digest_items WHERE echo_id = 1").fetchall()
         assert len(rows) == 0
+
+
+class TestDigestUnhandledErrorAlerting:
+    """Unhandled exceptions in _flush_one_digest (outside the send_email
+    guard) must feed record_failure so a permanently broken echo surfaces
+    through the notify threshold instead of failing silently every tick."""
+
+    def test_unhandled_digest_exception_calls_record_failure(self, db_tmp, monkeypatch):
+        import scheduler
+
+        sent_emails = []
+        monkeypatch.setattr(
+            scheduler, "send_email", lambda **kw: sent_emails.append(kw) or {"success": True}
+        )
+        echo = _setup_email_echo(db_tmp)
+        scheduler.process_echo(echo, _item(id="a1", title="From Feed 1"))
+
+        failures = []
+        monkeypatch.setattr(scheduler, "record_failure", failures.append)
+
+        def flaky_build(*, echo_row, **_):
+            raise RuntimeError("corrupt digest payload")
+
+        # Break body assembly inside _flush_one_digest, outside every
+        # existing guard.
+        monkeypatch.setattr(scheduler, "_build_digest_body", flaky_build, raising=False)
+
+        scheduler.flush_digests()
+
+        # The exception was contained to this echo and surfaced as a
+        # recorded failure; nothing was sent.
+        assert failures == [1]
+        assert sent_emails == []
+        with db_tmp.get_db() as db:
+            rows = db.execute(
+                "SELECT * FROM digest_items WHERE echo_id = 1"
+            ).fetchall()
+        assert len(rows) == 1  # untouched, retried next tick
+
+
+class TestDigestOrphanSweepIsolation:
+    """The orphan sweep runs BEFORE the per-echo digest loop, so one
+    orphan row's failure must not abort the whole sweep (or the tick) —
+    same bug class as the per-echo isolation below it."""
+
+    def test_one_bad_orphan_does_not_block_the_others(self, db_tmp, monkeypatch):
+        import scheduler
+
+        with db_tmp.get_db() as db:
+            # Three echoes whose feeds are deleted: all three are orphans
+            # the sweep must finalize. Deleting the echo itself would
+            # cascade its digest_items away, so orphan via feed deletion.
+            for n in (1, 2, 3):
+                db.execute(
+                    "INSERT INTO feeds (id, name, url, deleted_at)"
+                    " VALUES (?, ?, ?, '2026-09-01 00:00:00')",
+                    (n, f"f{n}", f"https://example.com/{n}"),
+                )
+                db.execute(
+                    """INSERT INTO echoes (feed_id, destination_type, destination_id, template,
+                                           visibility, filter_keywords, filter_mode,
+                                           content_warning, attach_image, delivery_mode, enabled)
+                       VALUES (?, 'email', 1, '{{ title }}', 'public', '', 'exclude', '', 0, 'digest', 1)""",
+                    (n,),
+                )
+                db.execute(
+                    """INSERT INTO posted_items (echo_id, item_id, status)
+                       VALUES (?, 'orphan-item', 'queued')""",
+                    (n,),
+                )
+                db.execute(
+                    """INSERT INTO digest_items (echo_id, item_id, rendered_content)
+                       VALUES (?, 'orphan-item', 'body')""",
+                    (n,),
+                )
+
+        real_now = scheduler._now
+        calls = {"n": 0}
+
+        def flaky_now():
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("transient DB error mid-sweep")
+            return real_now()
+
+        monkeypatch.setattr(scheduler, "_now", flaky_now)
+
+        # Must not raise even though one orphan row's update blew up.
+        scheduler.flush_digests()
+
+        with db_tmp.get_db() as db:
+            rows = db.execute(
+                "SELECT echo_id, status FROM posted_items WHERE item_id = 'orphan-item'"
+            ).fetchall()
+            leftover = db.execute(
+                "SELECT echo_id FROM digest_items"
+            ).fetchall()
+
+        by_status: dict[str, list[int]] = {}
+        for r in rows:
+            by_status.setdefault(r["status"], []).append(r["echo_id"])
+
+        # Exactly the row that raised stays queued (retried next tick);
+        # every other orphan was finalized as gave_up and cleared.
+        assert len(by_status.get("queued", [])) == 1
+        assert len(by_status.get("gave_up", [])) == 2
+        assert len(leftover) == 1
+        assert by_status["queued"][0] == leftover[0]["echo_id"]

--- a/tests/test_drip.py
+++ b/tests/test_drip.py
@@ -478,3 +478,65 @@ class TestDripAPI:
         with database.get_db() as db:
             row = db.execute("SELECT drip_limit FROM echoes WHERE id = 1").fetchone()
         assert row["drip_limit"] == 7
+
+
+def _set_state(database, echo_id, item_id, status):
+    with database.get_db() as db:
+        db.execute(
+            "UPDATE posted_items SET status = ? WHERE echo_id = ? AND item_id = ?",
+            (status, echo_id, item_id),
+        )
+
+
+class TestDripReleaseErrorRecovery:
+    """An unexpected exception escaping _render_and_dispatch must not lose
+    the drip item. Regression for the old ordering, which deleted the
+    drip_items row BEFORE dispatch: an escaped exception (infrastructure
+    fault, not a sender failure) left the posted row stranded 'pending'
+    forever and the queue entry gone — the item silently vanished."""
+
+    def test_dispatch_exception_requeues_instead_of_dropping(self, env, monkeypatch):
+        database, scheduler, _ = env
+        echo = _seed(env, drip_limit=2)
+        _queue_item(database, 1, "item-1", _item(id="item-1"))
+
+        attempts_seen = []
+        real_dispatch = scheduler._render_and_dispatch
+
+        def flaky_dispatch(echo, item, feed_name, posted_id, claim_token, **kw):
+            attempts_seen.append(posted_id)
+            raise RuntimeError("connection reset during dispatch")
+
+        monkeypatch.setattr(scheduler, "_render_and_dispatch", flaky_dispatch)
+
+        scheduler.flush_drips()
+
+        # First flush: dispatch blew up, so the item must be back in the
+        # queue and the posted row back to 'queued' with the claim cleared.
+        assert _drip_row_count(database, 1) == 1
+        assert _state(database, 1, "item-1") == "queued"
+        with database.get_db() as db:
+            row = db.execute(
+                "SELECT status, claim_token, attempt_count FROM posted_items"
+                " WHERE echo_id = 1 AND item_id = 'item-1'"
+            ).fetchone()
+            queue_row = db.execute(
+                "SELECT attempts FROM drip_items WHERE echo_id = 1"
+            ).fetchone()
+        assert row["claim_token"] is None
+        assert row["attempt_count"] == 0  # infrastructure fault, not a send failure
+        assert queue_row["attempts"] == 0
+
+        # Second flush with dispatch healthy: the same item releases
+        # normally, proving the requeue kept it deliverable. Restore the
+        # real dispatch and stub the sender so the full machinery runs
+        # and records success like a live release would.
+        monkeypatch.setattr(scheduler, "_render_and_dispatch", real_dispatch)
+        monkeypatch.setattr(
+            scheduler, "post_status", lambda **kw: {"id": "x", "url": "https://x/1"}
+        )
+        scheduler.flush_drips()
+
+        assert _state(database, 1, "item-1") == "success"
+        assert _drip_row_count(database, 1) == 0
+        assert len(attempts_seen) == 1

--- a/tests/test_feed_edit.py
+++ b/tests/test_feed_edit.py
@@ -257,7 +257,7 @@ class TestFeedEditInvalidatesSavedSearchCache:
             assert m, f"saved search {search_id} link not found in page"
             anchor = html[m.start(): html.find("</a>", m.end()) + 4]
             badge = re.search(
-                r'class="(?:reader-search-count|reader-feed-unread)"[^>]*>(\d+)</span>',
+                r'class="reader-search-count"[^>]*>(\d+)</span>',
                 anchor,
             )
             return int(badge.group(1)) if badge else 0

--- a/tests/test_feed_edit.py
+++ b/tests/test_feed_edit.py
@@ -250,12 +250,16 @@ class TestFeedEditInvalidatesSavedSearchCache:
 
         def _saved_search_badge(html: str, search_id: int) -> int:
             m = re.search(
-                r'href="/reader\?saved=%d(?:&amp;fulltext=1)?".*?</a>' % search_id,
+                r'href="/reader\?saved=%d(?:&amp;fulltext=1)?"' % search_id,
                 html,
                 re.S,
             )
             assert m, f"saved search {search_id} link not found in page"
-            badge = re.search(r'reader-feed-unread">(\d+)</span>', m.group(0))
+            anchor = html[m.start(): html.find("</a>", m.end()) + 4]
+            badge = re.search(
+                r'class="(?:reader-search-count|reader-feed-unread)"[^>]*>(\d+)</span>',
+                anchor,
+            )
             return int(badge.group(1)) if badge else 0
 
         # Populate the cache: unmuted, "widget" matches the one unread item.

--- a/tests/test_mobile_form_layout.py
+++ b/tests/test_mobile_form_layout.py
@@ -83,7 +83,7 @@ class TestMobileFormLayout:
 
     def test_cache_buster_bumped(self):
         base = (REPO_ROOT / "templates" / "base.html").read_text(encoding="utf-8")
-        assert 'style.css?v=58' in base, "CSS changed; bump the cache-buster so phones pick it up"
+        assert 'style.css?v=59' in base, "CSS changed; bump the cache-buster so phones pick it up"
 
     def test_smtp_test_email_label_is_visible(self):
         page = (REPO_ROOT / "templates" / "settings.html").read_text(encoding="utf-8")

--- a/tests/test_mobile_nav.py
+++ b/tests/test_mobile_nav.py
@@ -115,4 +115,4 @@ class TestNavTemplate:
         assert BASE_HTML.count('action="/logout"') == 2
 
     def test_cache_buster_bumped(self):
-        assert 'style.css?v=58' in BASE_HTML
+        assert 'style.css?v=59' in BASE_HTML

--- a/tests/test_reader_folders.py
+++ b/tests/test_reader_folders.py
@@ -155,8 +155,9 @@ def _create_saved_search(client, name, query):
 def _saved_search_badge(html: str, s_id: int) -> int:
     """Extract the sidebar count badge for one saved search's link.
 
-    Saved-search badges use ``reader-search-count``; older pages/HTML used
-    the unread pill class, so match both to keep the helper robust.
+    Strict to ``reader-search-count`` (the muted total-match styling);
+    scoped to the saved search's own <a> block so a per-feed unread badge
+    with the same digits can never satisfy this check.
     """
     m = re.search(
         r'href="/reader\?saved=%d(?:&amp;fulltext=1)?"' % s_id,
@@ -164,11 +165,9 @@ def _saved_search_badge(html: str, s_id: int) -> int:
         re.S,
     )
     assert m, f"saved search {s_id} link not found in page"
-    # Scope to the saved search's own <a> block so a per-feed unread badge
-    # with the same digits can never satisfy this check.
     anchor = html[m.start(): html.find("</a>", m.end()) + 4]
     badge = re.search(
-        r'class="(?:reader-search-count|reader-feed-unread)"[^>]*>(\d+)</span>', anchor
+        r'class="reader-search-count"[^>]*>(\d+)</span>', anchor
     )
     return int(badge.group(1)) if badge else 0
 

--- a/tests/test_reader_folders.py
+++ b/tests/test_reader_folders.py
@@ -153,14 +153,23 @@ def _create_saved_search(client, name, query):
 
 
 def _saved_search_badge(html: str, s_id: int) -> int:
-    """Extract the sidebar count badge for one saved search's link."""
+    """Extract the sidebar count badge for one saved search's link.
+
+    Saved-search badges use ``reader-search-count``; older pages/HTML used
+    the unread pill class, so match both to keep the helper robust.
+    """
     m = re.search(
-        r'href="/reader\?saved=%d(?:&amp;fulltext=1)?".*?</a>' % s_id,
+        r'href="/reader\?saved=%d(?:&amp;fulltext=1)?"' % s_id,
         html,
         re.S,
     )
     assert m, f"saved search {s_id} link not found in page"
-    badge = re.search(r'reader-feed-unread">(\d+)</span>', m.group(0))
+    # Scope to the saved search's own <a> block so a per-feed unread badge
+    # with the same digits can never satisfy this check.
+    anchor = html[m.start(): html.find("</a>", m.end()) + 4]
+    badge = re.search(
+        r'class="(?:reader-search-count|reader-feed-unread)"[^>]*>(\d+)</span>', anchor
+    )
     return int(badge.group(1)) if badge else 0
 
 

--- a/tests/test_reader_saved_searches.py
+++ b/tests/test_reader_saved_searches.py
@@ -26,7 +26,9 @@ def _saved_search_badge(html: str, s_id: int) -> int:
         re.S,
     )
     assert m, f"saved search {s_id} link not found in page"
-    badge = re.search(r'reader-feed-unread">(\d+)</span>', m.group(0))
+    badge = re.search(
+        r'class="(?:reader-search-count|reader-feed-unread)"[^>]*>(\d+)</span>', m.group(0)
+    )
     return int(badge.group(1)) if badge else 0
 
 
@@ -148,11 +150,11 @@ def test_reader_saved_search_view_and_counts(p5_env):
     assert r_page.status_code == 200
     html = r_page.text
 
-    # Sidebar contains saved search section and unread badge
+    # Sidebar contains saved search section and count badge
     assert "Saved Searches" in html
     assert "AI Unread" in html
     # it-1 is unread and contains AI; it-3 is read; it-2 has no AI. So count is 1.
-    assert '<span class="reader-feed-unread">1</span>' in html
+    assert _saved_search_badge(html, s_id) == 1
     # The item list should show "AI Breakthrough announced"
     assert "AI Breakthrough announced" in html
     # and should NOT show "Old AI Paper" because of is:unread
@@ -201,3 +203,46 @@ def test_saved_searches_plan_allowance_enforced(p5_env):
     )
     assert r4.status_code == 402
     assert "allows 3 saved searches" in r4.json()["detail"]
+
+
+def test_saved_search_badge_uses_count_styling_not_unread_pill(p5_env):
+    """Saved-search badges count TOTAL matches, so they must render the
+    muted .reader-search-count class — not .reader-feed-unread, which
+    brands a permanent total as an unread counter that never clears."""
+    r_create = p5_env.post(
+        "/api/saved-searches",
+        data={"name": "AI Everything", "query": "AI"},
+        headers={"Accept": "application/json"},
+    )
+    s_id = r_create.json()["id"]
+
+    html = p5_env.get(f"/reader?saved={s_id}").text
+
+    assert _saved_search_badge(html, s_id) == 2
+    m = re.search(
+        r'href="/reader\?saved=%d(?:&amp;fulltext=1)?"' % s_id, html, re.S
+    )
+    anchor = html[m.start(): html.find("</a>", m.end()) + 4]
+    assert 'class="reader-search-count"' in anchor
+    assert 'class="reader-feed-unread"' not in anchor
+
+
+def test_saved_search_badge_count_survives_mark_all_read(p5_env):
+    """The badge is a match-count monitor: reading everything it matched
+    must leave the count intact (it is not an unread counter), and mark
+    all read must not corrupt or zero it."""
+    r_create = p5_env.post(
+        "/api/saved-searches",
+        data={"name": "AI Everything", "query": "AI"},
+        headers={"Accept": "application/json"},
+    )
+    s_id = r_create.json()["id"]
+
+    before = _saved_search_badge(p5_env.get(f"/reader?saved={s_id}").text, s_id)
+    assert before == 2
+
+    r = p5_env.post("/api/reader/mark-all-read", data={"feed_id": "10"})
+    assert r.status_code == 200
+
+    after = _saved_search_badge(p5_env.get(f"/reader?saved={s_id}").text, s_id)
+    assert after == 2

--- a/tests/test_reader_saved_searches.py
+++ b/tests/test_reader_saved_searches.py
@@ -13,21 +13,22 @@ import scheduler
 
 
 def _saved_search_badge(html: str, s_id: int) -> int:
-    """Extract the sidebar unread-count badge for one saved search's link.
+    """Extract the sidebar count badge for one saved search's link.
 
-    Both the per-feed unread badge and the saved-search badge share the
-    ``reader-feed-unread`` class, so a plain substring/regex search over
-    the whole page can accidentally match the wrong badge when the two
-    counts collide. Scope the search to the saved search's own <a> block.
+    Strict to ``reader-search-count`` (the muted total-match styling): a
+    regression back to the unread pill renders 0 here instead of a number,
+    so count assertions pin the restyle too. Scoped to the saved search's
+    own <a> block so a per-feed badge with the same digits can't satisfy it.
     """
     m = re.search(
-        r'href="/reader\?saved=%d(?:&amp;fulltext=1)?".*?</a>' % s_id,
+        r'href="/reader\?saved=%d(?:&amp;fulltext=1)?"' % s_id,
         html,
         re.S,
     )
     assert m, f"saved search {s_id} link not found in page"
+    anchor = html[m.start(): html.find("</a>", m.end()) + 4]
     badge = re.search(
-        r'class="(?:reader-search-count|reader-feed-unread)"[^>]*>(\d+)</span>', m.group(0)
+        r'class="reader-search-count"[^>]*>(\d+)</span>', anchor
     )
     return int(badge.group(1)) if badge else 0
 

--- a/tests/test_trial_limits_visibility.py
+++ b/tests/test_trial_limits_visibility.py
@@ -170,7 +170,7 @@ class TestTrialLimitsOnDashboard:
         base = (Path(__file__).resolve().parent.parent / "templates" / "base.html").read_text(
             encoding="utf-8"
         )
-        assert 'style.css?v=58' in base
+        assert 'style.css?v=59' in base
 
 
 class TestBillingCtaSeam:

--- a/tests/test_ux_p2_fixes.py
+++ b/tests/test_ux_p2_fixes.py
@@ -377,4 +377,4 @@ class TestAppJsP2:
 
     def test_asset_versions_bumped(self):
         base = _tpl("base.html")
-        assert 'style.css?v=58' in base and 'app.js?v=52' in base
+        assert 'style.css?v=59' in base and 'app.js?v=52' in base


### PR DESCRIPTION
Follow-ups from the PR #27 review gate (Gemini 3.8), the PR #28 F-01 product call, and one catch of my own.

## Scheduler (closes PR #27 review findings)
- **[MEDIUM] Orphan sweep isolation** — `_discard_orphaned_digest_items()` runs before the per-echo digest loop; one bad orphan row aborted the whole digest tick. Now per-row try/except, mirroring the flush loops.
- **[LOW] Silent digest failures** — unhandled `_flush_one_digest` exceptions never called `record_failure`, so a permanently broken echo failed silently every tick. Now recorded (the `send_email` path already did; only exceptions outside it were silent).
- **[LOW] Drip items lost on interrupted dispatch** — `_flush_one_drip` deleted the `drip_items` row before dispatch; an exception escaping `_render_and_dispatch` left the posted row stranded `pending` forever and the item silently gone. Dispatch now runs first; an escaped exception requeues via new `_requeue_drip_release_error` (single transaction: `pending`→`queued`, claim cleared, queue row restored, attempts held — infrastructure faults don't burn retry budget).

## Reader badge (closes PR #28 F-01)
Saved-search badges count **total matches** (deliberate, matches the page), so they now render the new muted `.reader-search-count` class instead of `.reader-feed-unread` — a permanent total styled as an unread pill never clears and misleads. Kept total-count semantics; unread-view behavior for saved searches remains a separate product decision. `style.css` v=59.

## Tests
7 new tests, each **swap-tested to fail on the pre-fix code** (old scheduler/template/CSS restored in a scratch run: 4/4 scheduler+badge tests failed there as expected). Covers: dispatch-exception requeue + healthy re-release, digest unhandled exception → `record_failure`, orphan-sweep fault containment (order-agnostic), badge class + count-survives-mark-all-read. Suite: 1520 passed, 1 skipped.

Fixes remaining findings from docs/reviews/2026-09-09-bug-review.md follow-up triage (PR #27/#28 review gates).