### PR TITLE
fix: Mastodon connect blocked by CSP form-action; validate instance input

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ import secrets
 import secrets as _secrets
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlparse
 
 from fastapi import FastAPI, Request, Form, HTTPException, UploadFile, File
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
@@ -649,14 +649,32 @@ _BILLING_FORM_ACTION_ORIGINS = (
 )
 
 
-def _csp_header() -> str:
+# The accounts-page connect form is a form submission (GET forms count)
+# whose redirect chain lands on the user-chosen Mastodon instance's
+# /oauth/authorize. The browser enforces form-action on EVERY hop of a
+# form submission's redirect chain, and that origin is unbounded, so the
+# directive has to allow https: at scheme level. Without it, connecting
+# ANY instance was silently blocked client-side (reported 2026-09-10,
+# same defect class as the Stripe form-action regression below).
+#
+# The wide directive is scoped to the pages that render the connect form
+# (/accounts, and /oauth/connect for its error banner): form-action exists
+# to stop cross-origin form hijacking on credential forms (login, register,
+# admin), and those pages have no business posting anywhere off-origin.
+# Review-gate finding (Gemini 3.8 Flash, 2026-09-10): the first cut applied
+# it to every response.
+_FORM_ACTION_WIDE_PAGES = ("/accounts", "/oauth/connect")
+
+
+def _csp_header(path: str | None = None) -> str:
     """Compose the CSP for a response.
 
     Reads settings.BILLING_ENABLED per response rather than baking it in at
     import: the flag is env-fixed in production, and per-request composition
     keeps tests able to flip it without reimporting the app.
     """
-    form_action = "form-action 'self'"
+    wide = path is not None and path.rstrip("/") in _FORM_ACTION_WIDE_PAGES
+    form_action = "form-action 'self' https:" if wide else "form-action 'self'"
     if settings.BILLING_ENABLED:
         form_action += " " + _BILLING_FORM_ACTION_ORIGINS
     return f"{_CSP_BASE}; {form_action}"
@@ -685,7 +703,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
                 "camera=(), microphone=(), geolocation=(), payment=()"
             )
         if "Content-Security-Policy" not in h:
-            h["Content-Security-Policy"] = _csp_header()
+            # The wide form-action (https:) is needed only on the pages that
+            # render the Mastodon connect form — see _FORM_ACTION_WIDE_PAGES.
+            h["Content-Security-Policy"] = _csp_header(request.url.path)
         # Emit HSTS unconditionally: browsers ignore the header over plain HTTP
         # (RFC 6797), so it is safe on http:// and correct on https://. Gating on
         # request.url.scheme silently fails behind a TLS-terminating reverse
@@ -937,13 +957,22 @@ def validate_url(url: str) -> str:
 
     Combines scheme check with SSRF protection (blocks private IPs,
     internal hostnames, non-http schemes, embedded credentials).
+    Malformed URLs that make urllib.parse.urlsplit itself raise ValueError
+    (unclosed IPv6 brackets like "https://[::1") are re-raised as 400s:
+    previously they escaped as an unhandled 500 (review-gate finding,
+    2026-09-10; the same ValueError path is reachable from the manual
+    add-account form).
     """
     if not re.match(r"^https?://", url):
         raise HTTPException(status_code=400, detail="URL must start with http:// or https://")
     try:
         validate_outbound_url(url)
     except SSRFError as e:
+        # SSRFError subclasses ValueError, so this clause MUST come first:
+        # an SSRF rejection should read as one, not as generic malformedness.
         raise HTTPException(status_code=400, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"URL is malformed: {e}") from e
     return url.rstrip("/")
 
 
@@ -5919,13 +5948,66 @@ def preview_template(
 
 # ── API: OAuth ───────────────────────────────────────────────────────────────
 
+def _display_instance(instance: str) -> str:
+    """Sanitize an instance string for display in a user-facing banner.
+
+    The raw input can carry embedded credentials (user:password@host);
+    echoing it verbatim would print the password back into the page.
+    Show the URL without userinfo when it parses, else a fixed label.
+    Review-gate finding (Gemini 3.8 Flash, 2026-09-10).
+    """
+    try:
+        parsed = urlsplit(instance)
+        if parsed.username or parsed.password:
+            host = parsed.hostname or ""
+            port = f":{parsed.port}" if parsed.port else ""
+            return f"{parsed.scheme}://{host}{port}"
+    except ValueError:
+        pass
+    return instance
+
+
 @app.get("/oauth/connect")
 def oauth_connect(request: Request, instance: str = ""):
     """Start a session-bound Mastodon OAuth authorization flow."""
     if not instance:
         raise HTTPException(status_code=400, detail="Instance URL is required")
 
-    instance = validate_url(instance)
+    # Form input ("social.lol") is common; default the scheme to https
+    # instead of bouncing the user to a raw 400 JSON page. Only prefix when
+    # no scheme is present — a URL that already carries one must pass
+    # through validation unchanged.
+    instance = instance.strip().rstrip("/")
+    if "://" not in instance:
+        instance = f"https://{instance}"
+
+    try:
+        instance = validate_url(instance)
+    except HTTPException:
+        return _render_accounts_error(
+            request,
+            f"{_display_instance(instance)} isn't a usable Mastodon instance. "
+            "Check the URL (for example https://dmv.community) and try again.",
+        )
+
+    # OAuth authorization and token endpoints must be TLS (RFC 6749 3.1.3
+    # requires it for the user's credentials to survive the browser trip).
+    # http:// here would also be killed by the page's own CSP form-action
+    # ('self' https:) a hop later — reject it up front with a readable
+    # message instead.
+    if instance.startswith("http://"):
+        return _render_accounts_error(
+            request,
+            f"{_display_instance(instance)} uses http://, but Mastodon "
+            "instances must be reachable over https. Check the address.",
+        )
+
+    # Reduce to scheme + host so the authorize URL is always
+    # {origin}/oauth/authorize and oauth_apps caches on a stable origin —
+    # stray paths (/web, /@user) or query strings would otherwise corrupt
+    # both (review-gate finding, 2026-09-10).
+    parsed = urlparse(instance)
+    instance = f"{parsed.scheme}://{parsed.netloc}"
 
     # This cookie is independent from shared-secret auth. It ties the OAuth
     # callback to the browser session that initiated the flow.

--- a/tests/test_oauth_connect_validation.py
+++ b/tests/test_oauth_connect_validation.py
@@ -1,0 +1,205 @@
+"""OAuth connect flow validation and CSP form-action coverage.
+
+Regression tests for the bug Alex Pardoe reported on 2026-09-10:
+
+1. The accounts-page connect form is <form method="get" action="/oauth/connect">,
+   and the route 302s to the user-chosen instance's /oauth/authorize. Browsers
+   enforce CSP form-action on EVERY hop of a form submission's redirect chain,
+   so the document rendering the form needs form-action 'self' https: — a
+   fixed-origin whitelist can never cover user-chosen Mastodon instances
+   (social.lol was blocked client-side with only a console error). The wide
+   directive is scoped to the connect-form pages (/accounts, /oauth/connect);
+   other pages keep strict 'self'.
+
+2. Entering the instance without a scheme ("social.lol") raised a 400
+   HTTPException that no HTML handler covers, so the browser showed raw JSON
+   after a normal form submission. The route now defaults scheme-less input to
+   https://, reduces the input to its origin, enforces https-only, and renders
+   the accounts page with a friendly banner when the URL fails validation
+   (including malformed URLs that previously escaped as unhandled 500s).
+"""
+
+import pathlib
+import tempfile
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app as app_module
+import database
+import oauth as oauth_module
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    tmp = tempfile.mkdtemp()
+    monkeypatch.setattr(database, "DB_PATH", str(pathlib.Path(tmp) / "test.db"))
+    # Single mode is the default (FEEDECHO_MODE unset); AUTH_TOKEN unset makes
+    # AuthMiddleware a no-op, so the routes under test are reachable.
+    with TestClient(app_module.app) as c:
+        yield c
+
+
+@pytest.fixture()
+def fake_instance_app(monkeypatch):
+    """Keep get_authorize_url real (it builds the actual redirect URL) but
+    stub the instance app registration so no network call happens."""
+    monkeypatch.setattr(
+        oauth_module,
+        "get_or_create_app",
+        lambda instance, allow_refresh=True: {
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+        },
+    )
+
+
+class TestConnectInstanceNormalization:
+    def test_bare_domain_defaults_to_https(self, client, fake_instance_app):
+        r = client.get(
+            "/oauth/connect",
+            params={"instance": "social.lol"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+        assert r.headers["location"].startswith(
+            "https://social.lol/oauth/authorize?"
+        )
+
+    def test_whitespace_and_trailing_slash_are_tolerated(
+        self, client, fake_instance_app
+    ):
+        r = client.get(
+            "/oauth/connect",
+            params={"instance": "  social.lol/  "},
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+        assert r.headers["location"].startswith(
+            "https://social.lol/oauth/authorize?"
+        )
+
+    def test_explicit_scheme_is_preserved(self, client, fake_instance_app):
+        r = client.get(
+            "/oauth/connect",
+            params={"instance": "https://social.lol"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+        assert r.headers["location"].startswith(
+            "https://social.lol/oauth/authorize?"
+        )
+
+    def test_path_and_query_are_stripped_to_origin(self, client, fake_instance_app):
+        # social.lol/web?utm_source=x must not corrupt the authorize URL
+        # (https://social.lol?utm_source=x/oauth/authorize) or the oauth_apps
+        # cache key. (Review-gate finding, 2026-09-10.)
+        r = client.get(
+            "/oauth/connect",
+            params={"instance": "https://social.lol/web?utm_source=x"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+        assert r.headers["location"].startswith(
+            "https://social.lol/oauth/authorize?"
+        )
+
+
+class TestConnectValidationErrors:
+    def test_unusable_instance_renders_banner_not_raw_json(
+        self, client, fake_instance_app
+    ):
+        # A URL that still fails validation after normalization (no host here)
+        # used to raise a bare 400 HTTPException; browsers showed raw JSON.
+        r = client.get(
+            "/oauth/connect", params={"instance": ":bad"}, follow_redirects=False
+        )
+        assert r.status_code == 200
+        assert "text/html" in r.headers["content-type"]
+        assert "isn&#39;t a usable Mastodon instance" in r.text
+        # The accounts page rendered (its connect form is present), so the
+        # user can correct the input without hitting back.
+        assert "/oauth/connect" in r.text
+
+    def test_malformed_ipv6_bracket_renders_banner_not_500(
+        self, client, fake_instance_app
+    ):
+        # urllib.parse.urlsplit raises ValueError("Invalid IPv6 URL") on
+        # unclosed brackets; that used to escape as an unhandled 500.
+        r = client.get(
+            "/oauth/connect",
+            params={"instance": "https://[::1"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 200
+        assert "isn&#39;t a usable Mastodon instance" in r.text
+
+    def test_ssrf_guarded_host_renders_banner(self, client, fake_instance_app):
+        r = client.get(
+            "/oauth/connect",
+            params={"instance": "http://127.0.0.1:8453"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 200
+        assert "isn&#39;t a usable Mastodon instance" in r.text
+
+    def test_plain_http_instance_is_rejected_with_banner(
+        self, client, fake_instance_app, monkeypatch
+    ):
+        # http:// would sail through validate_url and then be killed by the
+        # page's own CSP form-action ('self' https:) a hop later — reject it
+        # up front with a readable message. (RFC 6749 3.1.3: TLS required.)
+        # Bypass only the DNS-based SSRF half (public DNS is not a test
+        # dependency); the http rejection under test happens after it.
+        monkeypatch.setattr(
+            app_module, "validate_outbound_url", lambda url: url
+        )
+        r = client.get(
+            "/oauth/connect",
+            params={"instance": "http://insecure.example.com"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 200
+        assert "must be reachable over https" in r.text
+
+    def test_userinfo_password_is_not_echoed_in_banner(
+        self, client, fake_instance_app
+    ):
+        # Embedded credentials are an SSRF-rejection; the banner must not
+        # print the password back into the page. (Review-gate finding.)
+        r = client.get(
+            "/oauth/connect",
+            params={"instance": "https://user:sekrit@127.0.0.1"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 200
+        assert "sekrit" not in r.text
+
+    def test_missing_instance_still_400(self, client):
+        # Direct URL hit with no instance parameter: the form's `required`
+        # attribute guards the browser path, and API callers get JSON.
+        r = client.get("/oauth/connect", follow_redirects=False)
+        assert r.status_code == 400
+
+
+class TestConnectFormPageCSP:
+    def test_accounts_page_carries_wide_form_action(self, client):
+        csp = client.get("/accounts").headers.get("Content-Security-Policy", "")
+        assert "form-action 'self' https:" in csp
+
+    def test_connect_error_page_carries_wide_form_action(
+        self, client, fake_instance_app
+    ):
+        # The error banner renders from /oauth/connect itself; its document
+        # hosts the same form, so it needs the same directive.
+        r = client.get(
+            "/oauth/connect", params={"instance": ":bad"}, follow_redirects=False
+        )
+        csp = r.headers.get("Content-Security-Policy", "")
+        assert "form-action 'self' https:" in csp
+
+    def test_healthz_keeps_strict_form_action(self, client):
+        csp = client.get("/healthz").headers.get("Content-Security-Policy", "")
+        directives = {p.strip() for p in csp.split(";") if p.strip()}
+        assert "form-action 'self'" in directives
+        assert "form-action 'self' https:" not in directives

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -37,12 +37,42 @@ def test_security_headers_present_on_html(client):
 
 
 def test_csp_stays_strict_when_billing_disabled(client, monkeypatch):
-    # Self-hosted: no billing seam is mounted, so no form submission ever
-    # needs to leave the origin — form-action stays at exactly 'self'.
+    # Self-hosted: no billing seam is mounted, so no form submission beyond
+    # the Mastodon connect form ever needs to leave the origin. Default
+    # pages keep the strict directive — pinned as an exact token set, not a
+    # substring: "form-action 'self'" is a prefix of the wide
+    # "form-action 'self' https:" and a bare `in` passes vacuously (gate
+    # finding, 2026-09-10).
     monkeypatch.setattr(settings, "BILLING_ENABLED", False)
     csp = client.get("/healthz").headers.get("Content-Security-Policy", "")
-    assert "form-action 'self'" in csp
+    directives = {p.strip() for p in csp.split(";") if p.strip()}
+    assert "form-action 'self'" in directives
+    assert "form-action 'self' https:" not in directives
     assert "stripe.com" not in csp
+
+
+def test_csp_form_action_wide_only_on_connect_form_pages(client):
+    # /accounts renders the connect form whose redirect chain leaves the
+    # origin, so its document needs form-action 'self' https:. Credential
+    # pages (login, register, admin) do NOT — pin the difference: the same
+    # directive on both would mean the scoping silently regressed.
+    def form_action_of(path):
+        csp = client.get(path).headers.get("Content-Security-Policy", "")
+        return next(
+            p.strip() for p in csp.split(";") if p.strip().startswith("form-action")
+        )
+
+    assert form_action_of("/accounts") == "form-action 'self' https:"
+    assert form_action_of("/login") == "form-action 'self'"
+
+
+def test_csp_wide_pages_include_stripe_when_billing_enabled(client, monkeypatch):
+    monkeypatch.setattr(settings, "BILLING_ENABLED", True)
+    csp = client.get("/accounts").headers.get("Content-Security-Policy", "")
+    assert (
+        "form-action 'self' https: https://checkout.stripe.com https://billing.stripe.com"
+        in csp
+    )
 
 
 def test_csp_allows_stripe_redirects_when_billing_enabled(client, monkeypatch):
@@ -53,13 +83,28 @@ def test_csp_allows_stripe_redirects_when_billing_enabled(client, monkeypatch):
     # both origins must be listed or the redirect is silently killed and
     # the customer never reaches the payment page (the v1.42.0 regression,
     # fixed 2026-09-10). Pinned as a full directive: an exact-match here is
-    # what a future CSP edit must consciously update.
+    # what a future CSP edit must consciously update. Non-connect pages
+    # keep Stripe WITHOUT the wide scheme: 'self' https: would make the
+    # pinned assertion vacuous.
     monkeypatch.setattr(settings, "BILLING_ENABLED", True)
     csp = client.get("/healthz").headers.get("Content-Security-Policy", "")
     assert (
         "form-action 'self' https://checkout.stripe.com https://billing.stripe.com"
         in csp
     )
+
+
+def test_csp_form_action_allows_https_redirect_hops(client):
+    # The accounts-page connect form is a form submission (method="get" is
+    # still a form submission for CSP) whose redirect chain lands on the
+    # user-chosen Mastodon instance's /oauth/authorize. form-action is
+    # enforced on EVERY hop, and the instance origin is unbounded, so the
+    # only honest allowance is scheme-level: 'self' plus https:. Without
+    # it, connecting any instance was blocked client-side with only a
+    # console error (reported by a beta user 2026-09-10, same defect class
+    # as the Stripe form-action regression).
+    csp = client.get("/accounts").headers.get("Content-Security-Policy", "")
+    assert "form-action 'self' https:" in csp
 
 
 def test_hsts_emitted_unconditionally(client):


### PR DESCRIPTION
## The bug (beta-user report, 2026-09-10)

Connecting any Mastodon instance from the accounts page failed client-side. The connect form is `<form method="get" action="/oauth/connect">` and the route 302s to the user-chosen instance's `/oauth/authorize`. Browsers enforce CSP `form-action` on **every hop of a form submission's redirect chain** — `form-action 'self'` (S8, v1.42.0) therefore killed the redirect to the instance, with only a console error:

> Refused to load https://social.lol/oauth/authorize?... because it does not appear in the form-action directive of the Content Security Policy.

Same defect class as the Stripe checkout regression fixed in v1.54.1 earlier today, but not covered by that fix: the instance origin is user-chosen and unbounded, so a fixed-origin whitelist can never cover it.

Second symptom, same page: entering the instance **without** a scheme (`social.lol`) raised a 400 `HTTPException` that no HTML handler covers, so a normal form submission showed raw JSON.

## The fix

**CSP (scoped, not global).** The pages that render the connect form (`/accounts`, `/oauth/connect`) now carry `form-action 'self' https:`; every other page keeps strict `'self'`. `/oauth/connect`'s error banner renders the same form, so its document needs the same directive. A scheme-level allowance is the only honest one for user-chosen instances; scoping keeps `form-action`'s anti-hijack value on credential pages. SSRF protection is unchanged and still enforced server-side before any redirect.

**Instance input.** `/oauth/connect` now:
- trims whitespace/trailing slashes, defaults scheme-less input to `https://` (`social.lol` works);
- rejects plain `http://` up front with a readable banner (RFC 6749 3.1.3 — and the page's own CSP would block it a hop later anyway);
- reduces input to its origin, so the authorize URL is always `{origin}/oauth/authorize` and the `oauth_apps` cache keys stay clean (`social.lol/web?utm_source=x` previously built a corrupted URL);
- renders the accounts page with a friendly banner instead of raw JSON when validation fails — including malformed URLs (e.g. `https://[::1`) that previously escaped `validate_url` as **unhandled 500s**;
- never echoes embedded credentials (`user:pass@host`) back into the banner.

`validate_url` now converts `urlsplit` `ValueError`s to 400s, which also fixes the same latent 500 for the manual add-account form.

## Verification

- New tests: `tests/test_oauth_connect_validation.py` (13 tests: normalization, banner-not-JSON, IPv6 500 regression, http rejection, credential non-echo, per-page CSP) + tightened/added assertions in `tests/test_security_headers.py` (strict-mode pins are exact token sets now; the old substring assertion passed vacuously against the wide directive).
- Full sqlite suite: **1613 passed** (was 1605 before the fix); PG suite: **1650 passed**.
- Ground-truth browser repro (stand-in server importing the real `SecurityHeadersMiddleware`, real form submit, violation listener): old header → blocked on page with a `form-action`/`enforce` violation; new header → 302 hop lands on the instance. This is the repro recipe the v1.54.1 reference mandates for any CSP change.
- Review gate: Gemini 3.8 Flash, 1 HIGH + 3 MEDIUM + 4 LOW, all triaged and addressed (per-page scoping, ValueError handling, https enforcement, origin normalization, banner sanitization, non-vacuous assertion, untracked test file).

Also fixes, en passant: an order-dependent PG test flake in `test_account_deletion.py` (the sqlite throttle test poisons `app._delete_attempts` and the PG suite's fresh small user id collides with it → spurious 200 instead of 303; reproduced on clean master; fixture now clears the bucket).