### PR TITLE
feat(bluesky): attach up to 4 images per post (parity with Mastodon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A hosted version with accounts, plans, and a 14-day free trial is live at [feede
 - **Visibility settings** — public, unlisted, private, direct (Mastodon)
 - **Drip mode** — cap an echo at N posts per hour; bursts queue up and release as the sliding window allows instead of flooding your timeline
 - **Content warnings** — per-echo CW text applied as Mastodon spoiler text
-- **Image attachments** — automatically attach the feed item's first image (Mastodon, Bluesky, and Matrix upload as media; micro.blog and Discord fetch it by URL)
+- **Image attachments** — automatically attach the feed item's images: up to 4 per post on Mastodon and Bluesky, up to 4 inline on email, and the first image on Matrix, micro.blog, and Discord
 - **AI alt text** — optionally generate image descriptions via an OpenAI-compatible vision API
 - **Digest mode** — batch email deliveries into hourly digests instead of one email per item
 - **Mobile-responsive** — tables convert to cards, forms stack, 44px touch targets
@@ -170,7 +170,7 @@ FeedEcho ships a Nix flake and a NixOS module. See [`nix/README.md`](nix/README.
 - Accounts connect via **App Passwords**, which are scoped to creating posts (and other app activity) and can be revoked individually without changing your main password.
 - Sessions are cached per account (access + refresh JWTs in SQLite) and refreshed automatically; expired tokens trigger a transparent re-login and one retry.
 - Posts are truncated to **300 graphemes** (Unicode-aware) and, separately, to Bluesky's 3000-byte limit on the post text; URLs in the text get proper link facets, so links are clickable everywhere.
-- Image attachments upload through the PDS blob API with an `app.bsky.embed.images` embed; alt text uses your AI vision config when enabled. Images are capped at 2 MB and jpeg/png/webp/gif (Bluesky's limits); oversized JPEG/PNG/WebP sources are downscaled or re-encoded to fit automatically.
+- Image attachments upload through the PDS blob API with an `app.bsky.embed.images` embed carrying **up to 4 images** per post; each image's alt text uses the feed's own description when it provides one, otherwise your AI vision config when enabled. Images are capped at 2 MB each and jpeg/png/webp/gif (Bluesky's limits); oversized JPEG/PNG/WebP sources are downscaled or re-encoded to fit automatically, and one image that fails to fetch or upload is skipped without dropping the rest of the post.
 - Content warnings and visibility settings are Mastodon-only and are ignored for Bluesky posts.
 
 ### Matrix details

--- a/bluesky.py
+++ b/bluesky.py
@@ -612,8 +612,12 @@ def build_image_embed(image_entries: list[dict]) -> dict:
 
     Takes a list of {"blob", "alt"} entries (scheduler._send_bluesky builds
     them) and drops anything beyond MAX_IMAGES defensively — the per-post
-    cap belongs to this transport, not the caller.
+    cap belongs to this transport, not the caller. The lexicon requires at
+    least one image, so an empty list raises ValueError instead of
+    returning a payload the PDS would reject.
     """
+    if not image_entries:
+        raise ValueError("build_image_embed requires at least one image entry")
     images = [
         {
             "alt": truncate_graphemes(

--- a/bluesky.py
+++ b/bluesky.py
@@ -38,6 +38,10 @@ MAX_ALT_GRAPHEMES = 1000
 # images.downscale_image before upload (scheduler._send_bluesky).
 MAX_BLOB_BYTES = 2_000_000
 BLUESKY_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
+# app.bsky.embed.images carries up to 4 images per post; scheduler._send_bluesky
+# attaches the item's image_urls up to this cap (Mastodon's default cap is the
+# same number, but the two are independent transport limits).
+MAX_IMAGES = 4
 
 # How long to trust a cached access JWT before refreshing (JWT exp takes
 # precedence when decodable). Access tokens typically live ~2 hours.
@@ -603,13 +607,23 @@ def create_post(
     return {"uri": data["uri"], "cid": data["cid"]}
 
 
-def build_image_embed(blob: dict, alt_text: str) -> dict:
-    """Wrap an uploaded blob in an app.bsky.embed.images embed."""
-    alt = truncate_graphemes((alt_text or "").strip(), MAX_ALT_GRAPHEMES)
-    return {
-        "$type": "app.bsky.embed.images",
-        "images": [{"alt": alt, "image": blob}],
-    }
+def build_image_embed(image_entries: list[dict]) -> dict:
+    """Wrap uploaded blobs in an app.bsky.embed.images embed.
+
+    Takes a list of {"blob", "alt"} entries (scheduler._send_bluesky builds
+    them) and drops anything beyond MAX_IMAGES defensively — the per-post
+    cap belongs to this transport, not the caller.
+    """
+    images = [
+        {
+            "alt": truncate_graphemes(
+                (entry.get("alt") or "").strip(), MAX_ALT_GRAPHEMES
+            ),
+            "image": entry["blob"],
+        }
+        for entry in image_entries[:MAX_IMAGES]
+    ]
+    return {"$type": "app.bsky.embed.images", "images": images}
 
 
 # ── Connection testing ───────────────────────────────────────────────────────

--- a/scheduler.py
+++ b/scheduler.py
@@ -1538,6 +1538,48 @@ def _bsky_session(account) -> dict:
     }
 
 
+def _bsky_reauth(account, session: dict) -> dict:
+    """Re-login with the stored app password after a rejected session.
+
+    Shared by the image-upload loop and the create_post retry so both heal
+    the same way. Returns the fresh session dict with the new tokens
+    persisted; raises BlueskyError when the account row is gone and
+    BlueskyAuthError when the credentials themselves are dead (callers map
+    that to a permanent failure).
+    """
+    with get_db() as db:
+        fresh = db.execute(
+            "SELECT handle, app_password FROM bluesky_accounts WHERE id = ?",
+            (account["id"],),
+        ).fetchone()
+    if not fresh:
+        raise BlueskyError("Bluesky account was deleted during dispatch")
+    refreshed = create_session(
+        session["pds"], fresh["handle"], decrypt_secret(fresh["app_password"])
+    )
+    with get_db() as db:
+        db.execute(
+            """
+            UPDATE bluesky_accounts
+               SET did = ?, access_jwt = ?, refresh_jwt = ?,
+                   session_expires_at = ?
+             WHERE id = ?
+            """,
+            (
+                refreshed["did"],
+                encrypt_secret(refreshed["access_jwt"]),
+                encrypt_secret(refreshed["refresh_jwt"]),
+                session_expiry(refreshed["access_jwt"]),
+                account["id"],
+            ),
+        )
+    return {
+        "pds": session["pds"],
+        "did": refreshed["did"],
+        "access_jwt": refreshed["access_jwt"],
+    }
+
+
 def _upload_bluesky_image(session: dict, echo, item: FeedItem, entry: dict) -> dict | None:
     """Fetch, downscale, and upload one image for a Bluesky post.
 
@@ -1669,29 +1711,59 @@ def _send_bluesky(
     image_entries_out: list[dict] = []
     if attach_image:
         image_entries = _item_image_entries(item, limit=BLUESKY_MAX_IMAGES)
-        try:
-            for entry in image_entries:
-                uploaded = _upload_bluesky_image(session, echo, item, entry)
-                if uploaded:
-                    image_entries_out.append(uploaded)
-        except BlueskyAuthError as e:
-            # The session died mid-dispatch. Unlike Mastodon (whose tokens
-            # need the user to reconnect), Bluesky re-logins with the stored
-            # app password, so fail transiently: the bounded retry sets up a
-            # fresh session and delivers the post WITH its images instead of
-            # publishing a degraded text-only post as a success.
-            logger.error(
-                "Echo %s: Bluesky session rejected during image upload for item %s: %s",
-                echo["id"],
-                item["id"],
-                e,
-            )
-            return _fail_post(
-                posted_id,
-                claim_token,
-                echo["id"],
-                "Bluesky session rejected during image upload",
-            )
+        for attempt in (1, 2):
+            try:
+                for entry in image_entries[len(image_entries_out):]:
+                    uploaded = _upload_bluesky_image(session, echo, item, entry)
+                    if uploaded:
+                        image_entries_out.append(uploaded)
+                break
+            except BlueskyAuthError:
+                # The session was rejected mid-dispatch. Re-login once with
+                # the stored app password and retry the remaining images —
+                # the same recovery the create_post path below uses. If the
+                # fresh login is rejected too, the credentials are dead and
+                # no retry can help.
+                logger.warning(
+                    "Echo %s: Bluesky session rejected during image upload for item %s, re-authenticating",
+                    echo["id"],
+                    item["id"],
+                )
+                if attempt == 2:
+                    logger.error(
+                        "Echo %s: Bluesky credentials rejected during image upload for item %s; giving up",
+                        echo["id"],
+                        item["id"],
+                    )
+                    return _fail_post(
+                        posted_id,
+                        claim_token,
+                        echo["id"],
+                        "Bluesky credentials rejected",
+                        permanent=True,
+                    )
+                try:
+                    session = _bsky_reauth(account, session)
+                except BlueskyAuthError:
+                    logger.error(
+                        "Echo %s: Bluesky credentials rejected after re-auth during image upload; giving up",
+                        echo["id"],
+                    )
+                    return _fail_post(
+                        posted_id,
+                        claim_token,
+                        echo["id"],
+                        "Bluesky credentials rejected",
+                        permanent=True,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Echo %s: Bluesky re-auth failed during image upload",
+                        echo["id"],
+                    )
+                    return _fail_post(
+                        posted_id, claim_token, echo["id"], "Bluesky delivery failed"
+                    )
         if image_entries and not image_entries_out:
             logger.warning(
                 "Echo %s: no images uploaded for item %s, posting text-only",
@@ -1727,37 +1799,10 @@ def _send_bluesky(
             account["handle"],
         )
         try:
-            with get_db() as db:
-                fresh = db.execute(
-                    "SELECT handle, app_password FROM bluesky_accounts WHERE id = ?",
-                    (account["id"],),
-                ).fetchone()
-            if not fresh:
-                raise BlueskyError("Bluesky account was deleted during dispatch")
-            refreshed = create_session(
-                session["pds"], fresh["handle"], decrypt_secret(fresh["app_password"])
-            )
-            with get_db() as db:
-                db.execute(
-                    """
-                    UPDATE bluesky_accounts
-                       SET did = ?, access_jwt = ?, refresh_jwt = ?,
-                           session_expires_at = ?
-                     WHERE id = ?
-                    """,
-                    (
-                        refreshed["did"],
-                        encrypt_secret(refreshed["access_jwt"]),
-                        encrypt_secret(refreshed["refresh_jwt"]),
-                        session_expiry(refreshed["access_jwt"]),
-                        account["id"],
-                    ),
-                )
-            # post_url below builds from session["did"]; point it at the DID
-            # that actually published (the re-login may have resolved it for
-            # the first time).
-            session["did"] = refreshed["did"]
-            result = _do_post(refreshed["access_jwt"], refreshed["did"])
+            # Rebinding session also updates the DID post_url builds from
+            # (the re-login may have resolved it for the first time).
+            session = _bsky_reauth(account, session)
+            result = _do_post(session["access_jwt"], session["did"])
         except BlueskyAuthError:
             # Credentials themselves are bad/revoked — retries cannot help.
             logger.error(

--- a/scheduler.py
+++ b/scheduler.py
@@ -37,6 +37,7 @@ from mastodon import (
 from bluesky import (
     BLUESKY_IMAGE_TYPES,
     MAX_BLOB_BYTES,
+    MAX_IMAGES as BLUESKY_MAX_IMAGES,
     MAX_POST_BYTES,
     MAX_POST_GRAPHEMES,
     BlueskyAuthError,
@@ -1537,6 +1538,89 @@ def _bsky_session(account) -> dict:
     }
 
 
+def _upload_bluesky_image(session: dict, echo, item: FeedItem, entry: dict) -> dict | None:
+    """Fetch, downscale, and upload one image for a Bluesky post.
+
+    Returns {"blob", "alt"} on success. A per-image failure (dead link,
+    unsupported type, still over the blob cap after a downscale attempt,
+    upload rejection) logs and returns None so the caller skips just this
+    image — one bad attachment never drops the whole post. Oversized images
+    are downscaled/re-encoded first (the 2026-09-09 glass.photo report:
+    ~2.9 MB source JPEGs degraded every glass post to text-only under the
+    old 1 MB cap).
+    """
+    try:
+        image_result = fetch_image(entry["url"])
+        if not image_result:
+            logger.info(
+                "Echo %s: image fetch failed for %s, skipping that image",
+                echo["id"],
+                entry["url"],
+            )
+            return None
+        img_bytes, img_type = image_result
+        # Oversized for Bluesky? Downscale/re-encode to fit. None = Pillow
+        # unavailable or still too big — skip just this image.
+        if len(img_bytes) > MAX_BLOB_BYTES:
+            downscaled = images.downscale_image(img_bytes, img_type, MAX_BLOB_BYTES)
+            if downscaled:
+                img_bytes, img_type = downscaled
+                logger.info(
+                    "Echo %s: downscaled Bluesky image for item %s to %d bytes (%s)",
+                    echo["id"],
+                    item["id"],
+                    len(img_bytes),
+                    img_type,
+                )
+            else:
+                logger.warning(
+                    "Echo %s: Bluesky image still exceeds the %d byte blob limit after downscale attempt for item %s, skipping that image",
+                    echo["id"],
+                    MAX_BLOB_BYTES,
+                    item["id"],
+                )
+                return None
+        if img_type not in BLUESKY_IMAGE_TYPES or len(img_bytes) > MAX_BLOB_BYTES:
+            logger.info(
+                "Echo %s: image unsupported for Bluesky (type=%s, size=%d), skipping that image",
+                echo["id"],
+                img_type,
+                len(img_bytes),
+            )
+            return None
+        # Feed-provided alt text wins; AI is the fallback.
+        alt_description = _resolve_alt_text(
+            echo, item, entry.get("alt", ""), img_bytes, img_type
+        ) or ""
+        blob = upload_blob(
+            pds=session["pds"],
+            access_jwt=session["access_jwt"],
+            image_bytes=img_bytes,
+            content_type=img_type,
+        )
+        if not blob:
+            logger.warning(
+                "Echo %s: Bluesky image upload failed for item %s, skipping that image",
+                echo["id"],
+                item["id"],
+            )
+            return None
+        logger.info(
+            "Echo %s: uploaded Bluesky image blob for item %s",
+            echo["id"],
+            item["id"],
+        )
+        return {"blob": blob, "alt": alt_description}
+    except Exception:
+        logger.warning(
+            "Echo %s: Bluesky image pipeline failed for one image of item %s, skipping that image",
+            echo["id"],
+            item["id"],
+            exc_info=True,
+        )
+        return None
+
+
 def _send_bluesky(
     echo,
     item: FeedItem,
@@ -1570,96 +1654,20 @@ def _send_bluesky(
         logger.exception("Echo %s: Bluesky session failed", echo["id"])
         return _fail_post(posted_id, claim_token, echo["id"], "Bluesky session failed")
 
-    # Image attachment: optional, single image, with AI alt text when enabled.
-    # Any failure in the pipeline degrades to a text-only post.
+    # Image attachment: optional, up to BLUESKY_MAX_IMAGES images (Bluesky's
+    # per-post embed cap), each with its own alt text. A failure on any
+    # single image (fetch, downscale, type, upload) skips that image; only
+    # when none survive does the post degrade to text-only.
     attach_image = _echo_attach_image(echo)
 
-    image_blob = None
-    alt_description = ""
-    try:
-        if attach_image:
-            image_url = item.get("image_url", "")
-            if image_url:
-                image_result = fetch_image(image_url)
-                if image_result:
-                    img_bytes, img_type = image_result
-                    # Oversized for Bluesky? Downscale/re-encode to fit (the
-                    # 2026-09-09 glass.photo report: ~2.9 MB source JPEGs
-                    # degraded every glass post to text-only under the old
-                    # 1 MB cap). None = Pillow unavailable or still too big —
-                    # keep the existing skip-to-text-only fallback.
-                    if len(img_bytes) > MAX_BLOB_BYTES:
-                        downscaled = images.downscale_image(
-                            img_bytes, img_type, MAX_BLOB_BYTES
-                        )
-                        if downscaled:
-                            img_bytes, img_type = downscaled
-                            logger.info(
-                                "Echo %s: downscaled Bluesky image for item %s to %d bytes (%s)",
-                                echo["id"],
-                                item["id"],
-                                len(img_bytes),
-                                img_type,
-                            )
-                        else:
-                            logger.warning(
-                                "Echo %s: Bluesky image still exceeds the %d byte blob limit after downscale attempt for item %s, posting text-only",
-                                echo["id"],
-                                MAX_BLOB_BYTES,
-                                item["id"],
-                            )
-                    if img_type in BLUESKY_IMAGE_TYPES and len(img_bytes) <= MAX_BLOB_BYTES:
-                        # Feed-provided alt text wins; AI is the fallback.
-                        alt_description = _resolve_alt_text(
-                            echo,
-                            item,
-                            (item.get("image_alt") or "").strip(),
-                            img_bytes,
-                            img_type,
-                        ) or ""
-                        blob = upload_blob(
-                            pds=session["pds"],
-                            access_jwt=session["access_jwt"],
-                            image_bytes=img_bytes,
-                            content_type=img_type,
-                        )
-                        if blob:
-                            image_blob = blob
-                            logger.info(
-                                "Echo %s: uploaded Bluesky image blob for item %s",
-                                echo["id"],
-                                item["id"],
-                            )
-                        else:
-                            logger.warning(
-                                "Echo %s: Bluesky image upload failed for item %s, posting text-only",
-                                echo["id"],
-                                item["id"],
-                            )
-                    else:
-                        logger.info(
-                            "Echo %s: image unsupported for Bluesky (type=%s, size=%d), posting text-only",
-                            echo["id"],
-                            img_type,
-                            len(img_bytes),
-                        )
-                else:
-                    logger.info(
-                        "Echo %s: image fetch failed for item %s, posting text-only",
-                        echo["id"],
-                        item["id"],
-                    )
-    except Exception:
-        logger.warning(
-            "Echo %s: Bluesky image pipeline failed for item %s, posting text-only",
-            echo["id"],
-            item["id"],
-            exc_info=True,
-        )
-        image_blob = None
-        alt_description = ""
+    image_entries_out: list[dict] = []
+    if attach_image:
+        for entry in _item_image_entries(item, limit=BLUESKY_MAX_IMAGES):
+            uploaded = _upload_bluesky_image(session, echo, item, entry)
+            if uploaded:
+                image_entries_out.append(uploaded)
 
-    embed = build_image_embed(image_blob, alt_description) if image_blob else None
+    embed = build_image_embed(image_entries_out) if image_entries_out else None
 
     # Re-validate claim ownership immediately before the post: if the lease
     # lapsed and another worker reclaimed this row, posting would duplicate.

--- a/scheduler.py
+++ b/scheduler.py
@@ -1711,12 +1711,22 @@ def _send_bluesky(
     image_entries_out: list[dict] = []
     if attach_image:
         image_entries = _item_image_entries(item, limit=BLUESKY_MAX_IMAGES)
+        # Index-based resume: a per-image skip does not advance
+        # image_entries_out, so the retry window must track the INPUT index —
+        # slicing by output count would re-upload an already-uploaded image
+        # as a duplicate after a re-auth.
+        start_idx = 0
         for attempt in (1, 2):
             try:
-                for entry in image_entries[len(image_entries_out):]:
+                for idx in range(start_idx, len(image_entries)):
+                    entry = image_entries[idx]
                     uploaded = _upload_bluesky_image(session, echo, item, entry)
                     if uploaded:
                         image_entries_out.append(uploaded)
+                    # Advance only after the entry has been handled (uploaded
+                    # or deliberately skipped); a BlueskyAuthError leaves the
+                    # index on the failed entry so the retry resumes there.
+                    start_idx = idx + 1
                 break
             except BlueskyAuthError:
                 # The session was rejected mid-dispatch. Re-login once with
@@ -1724,11 +1734,6 @@ def _send_bluesky(
                 # the same recovery the create_post path below uses. If the
                 # fresh login is rejected too, the credentials are dead and
                 # no retry can help.
-                logger.warning(
-                    "Echo %s: Bluesky session rejected during image upload for item %s, re-authenticating",
-                    echo["id"],
-                    item["id"],
-                )
                 if attempt == 2:
                     logger.error(
                         "Echo %s: Bluesky credentials rejected during image upload for item %s; giving up",
@@ -1742,6 +1747,11 @@ def _send_bluesky(
                         "Bluesky credentials rejected",
                         permanent=True,
                     )
+                logger.warning(
+                    "Echo %s: Bluesky session rejected during image upload for item %s, re-authenticating",
+                    echo["id"],
+                    item["id"],
+                )
                 try:
                     session = _bsky_reauth(account, session)
                 except BlueskyAuthError:

--- a/scheduler.py
+++ b/scheduler.py
@@ -1544,10 +1544,11 @@ def _upload_bluesky_image(session: dict, echo, item: FeedItem, entry: dict) -> d
     Returns {"blob", "alt"} on success. A per-image failure (dead link,
     unsupported type, still over the blob cap after a downscale attempt,
     upload rejection) logs and returns None so the caller skips just this
-    image — one bad attachment never drops the whole post. Oversized images
-    are downscaled/re-encoded first (the 2026-09-09 glass.photo report:
-    ~2.9 MB source JPEGs degraded every glass post to text-only under the
-    old 1 MB cap).
+    image — one bad attachment never drops the whole post. BlueskyAuthError
+    propagates instead: a dead session is a post-level problem, not an image
+    one. Oversized images are downscaled/re-encoded first (the 2026-09-09
+    glass.photo report: ~2.9 MB source JPEGs degraded every glass post to
+    text-only under the old 1 MB cap).
     """
     try:
         image_result = fetch_image(entry["url"])
@@ -1611,6 +1612,11 @@ def _upload_bluesky_image(session: dict, echo, item: FeedItem, entry: dict) -> d
             item["id"],
         )
         return {"blob": blob, "alt": alt_description}
+    except BlueskyAuthError:
+        # A dead session is post-level, not image-level: propagate so the
+        # caller fails the dispatch (fresh session on retry) instead of
+        # silently publishing a degraded text-only post.
+        raise
     except Exception:
         logger.warning(
             "Echo %s: Bluesky image pipeline failed for one image of item %s, skipping that image",
@@ -1662,10 +1668,36 @@ def _send_bluesky(
 
     image_entries_out: list[dict] = []
     if attach_image:
-        for entry in _item_image_entries(item, limit=BLUESKY_MAX_IMAGES):
-            uploaded = _upload_bluesky_image(session, echo, item, entry)
-            if uploaded:
-                image_entries_out.append(uploaded)
+        image_entries = _item_image_entries(item, limit=BLUESKY_MAX_IMAGES)
+        try:
+            for entry in image_entries:
+                uploaded = _upload_bluesky_image(session, echo, item, entry)
+                if uploaded:
+                    image_entries_out.append(uploaded)
+        except BlueskyAuthError as e:
+            # The session died mid-dispatch. Unlike Mastodon (whose tokens
+            # need the user to reconnect), Bluesky re-logins with the stored
+            # app password, so fail transiently: the bounded retry sets up a
+            # fresh session and delivers the post WITH its images instead of
+            # publishing a degraded text-only post as a success.
+            logger.error(
+                "Echo %s: Bluesky session rejected during image upload for item %s: %s",
+                echo["id"],
+                item["id"],
+                e,
+            )
+            return _fail_post(
+                posted_id,
+                claim_token,
+                echo["id"],
+                "Bluesky session rejected during image upload",
+            )
+        if image_entries and not image_entries_out:
+            logger.warning(
+                "Echo %s: no images uploaded for item %s, posting text-only",
+                echo["id"],
+                item["id"],
+            )
 
     embed = build_image_embed(image_entries_out) if image_entries_out else None
 
@@ -1721,6 +1753,10 @@ def _send_bluesky(
                         account["id"],
                     ),
                 )
+            # post_url below builds from session["did"]; point it at the DID
+            # that actually published (the re-login may have resolved it for
+            # the first time).
+            session["did"] = refreshed["did"]
             result = _do_post(refreshed["access_jwt"], refreshed["did"])
         except BlueskyAuthError:
             # Credentials themselves are bad/revoked — retries cannot help.

--- a/templates/echoes.html
+++ b/templates/echoes.html
@@ -141,7 +141,7 @@
         </label>
         <label>Attach image
             <input type="checkbox" name="attach_image" value="true">
-            <span class="hint" style="margin: 0.2rem 0 0;">Attach the feed item's first image. Mastodon, Bluesky, Matrix, and email send it with the post (email embeds images inline in instant mode); micro.blog fetches it by URL; Discord shows it in the post's embed. Webhook deliveries always include image_url in the payload.</span>
+            <span class="hint" style="margin: 0.2rem 0 0;">Attach the feed item's images. Mastodon and Bluesky attach up to 4 with alt text where available; email embeds up to 4 inline in instant mode; Matrix, micro.blog, and Discord use the first image. Webhook deliveries always include image_url in the payload.</span>
         </label>
     </div>
     <div class="form-row" id="microblog-fields"{{ dest_hidden('microblog') }}>

--- a/templates/howto.html
+++ b/templates/howto.html
@@ -75,7 +75,7 @@
             <ul>
                 <li><strong>Filter keywords</strong> — post only items containing a keyword, or skip items containing it.</li>
                 <li><strong>Content warning</strong> — for Mastodon, adds a spoiler label and marks posts sensitive.</li>
-                <li><strong>Attach image</strong> — include the item's image(s) with the post where the destination supports media uploads.</li>
+                <li><strong>Attach image</strong> — include the item's images with the post where the destination supports media uploads (up to 4 on Mastodon and Bluesky; email embeds up to 4 inline; Matrix, micro.blog, and Discord use the first).</li>
                 <li><strong>Drip limit</strong> — cap the echo at N posts per hour; extra items wait in a queue and release as the window slides. 0 = off.</li>
                 <li><strong>Digest</strong> — email destinations only; batches items into one email per hour instead of sending per item.</li>
             </ul>

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -797,12 +797,68 @@ class TestSendBluesky:
         assert len(sent) == 1
         assert len(sent[0]["embed"]["images"]) == 2  # both images made it
         assert len(uploads) == 3  # the rejected upload was retried once
+        assert uploads[0]["access_jwt"] == "aj-1"  # pre-re-auth upload
+        assert uploads[2]["access_jwt"] == "aj-2"  # retried with fresh token
+        assert sent[0]["access_jwt"] == "aj-2"  # post uses the rebound session
         assert logins["count"] == 2  # initial login + one re-auth
         with database.get_db() as db:
             account = db.execute(
                 "SELECT access_jwt FROM bluesky_accounts WHERE id = 1"
             ).fetchone()
             assert account["access_jwt"] == "aj-2"  # fresh session persisted
+
+    def test_skipped_image_before_auth_error_does_not_duplicate(
+        self, db_tmp, monkeypatch
+    ):
+        """A skipped image before the rejected upload must not shift the retry
+        window: already-uploaded images are never re-uploaded (the retry
+        resumes at the input index, not the success count)."""
+        import scheduler
+        from bluesky import BlueskyAuthError
+
+        sent = []
+        fetched = []
+        uploads = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+
+        def flaky_fetch(url):
+            fetched.append(url)
+            if "dead" in url:
+                return None  # skip: never uploaded
+            return (b"fake-image-bytes", "image/jpeg")
+
+        monkeypatch.setattr(scheduler, "fetch_image", flaky_fetch)
+
+        def flaky_upload(**kw):
+            uploads.append(kw)
+            if len(uploads) == 2:
+                raise BlueskyAuthError(
+                    "Blob upload rejected: session expired (ExpiredToken)"
+                )
+            return {"$type": "blob", "ref": {"$link": "bafkreifake"}}
+
+        monkeypatch.setattr(scheduler, "upload_blob", flaky_upload)
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/dead.jpg", "alt": ""},  # skipped
+            {"url": "https://example.com/1.jpg", "alt": ""},  # uploaded once
+            {"url": "https://example.com/2.jpg", "alt": ""},  # rejected, retried
+        ])
+        ok = scheduler.process_echo(echo, item)
+
+        assert ok is True
+        embed_images = sent[0]["embed"]["images"]
+        assert len(embed_images) == 2  # dead skipped; no duplicates
+        assert embed_images[0]["image"]["ref"]["$link"] == "bafkreifake"
+        assert len(uploads) == 3  # 1.jpg once, 2.jpg rejected + retried
+        assert fetched.count("https://example.com/1.jpg") == 1
 
     def test_auth_error_during_upload_with_dead_credentials_gives_up(
         self, db_tmp, monkeypatch
@@ -984,6 +1040,70 @@ class TestSendBluesky:
 
         echo = _setup_bluesky_echo(db_tmp)
         ok = scheduler.process_echo(echo, _item())
+
+        assert ok is True
+        with database.get_db() as db:
+            row = db.execute(
+                "SELECT post_url FROM posted_items WHERE echo_id = 1"
+            ).fetchone()
+        assert (
+            row["post_url"]
+            == "https://bsky.app/profile/did:plc:refreshed/post/u"
+        )
+
+    def test_post_url_uses_refreshed_did_after_upload_reauth(
+        self, db_tmp, monkeypatch
+    ):
+        """DID rotation triggered by a mid-upload rejection must also reach
+        post_url (the upload-loop re-auth rebinds the session for create_post)."""
+        import database
+        import scheduler
+        from bluesky import BlueskyAuthError
+
+        sent = []
+        uploads = []
+        logins = {"count": 0}
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+
+        def rotating_session(pds, handle, pw):
+            logins["count"] += 1
+            did = (
+                "did:plc:test123"
+                if logins["count"] == 1
+                else "did:plc:refreshed"
+            )
+            return {
+                "did": did,
+                "access_jwt": f"aj{logins['count']}",
+                "refresh_jwt": f"rj{logins['count']}",
+            }
+
+        monkeypatch.setattr(scheduler, "create_session", rotating_session)
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+
+        def flaky_upload(**kw):
+            uploads.append(kw)
+            if len(uploads) == 1:
+                raise BlueskyAuthError(
+                    "Blob upload rejected: session expired (ExpiredToken)"
+                )
+            return {"$type": "blob", "ref": {"$link": "bafkreifake"}}
+
+        monkeypatch.setattr(scheduler, "upload_blob", flaky_upload)
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/1.jpg", "alt": ""},
+        ])
+        ok = scheduler.process_echo(echo, item)
 
         assert ok is True
         with database.get_db() as db:

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -743,31 +743,45 @@ class TestSendBluesky:
             img["alt"] for img in sent[0]["embed"]["images"]
         ] == ["USER EDITED ALT", "AI-GENERATED"]
 
-    def test_auth_error_during_upload_fails_post_for_retry(self, db_tmp, monkeypatch):
-        """A session rejected mid-upload must fail the post (for a fresh-
-        session retry), never publish a text-only success with images
-        silently dropped."""
+    def test_auth_error_during_upload_reauthenticates_and_retries(self, db_tmp, monkeypatch):
+        """A session rejected mid-upload heals in the same dispatch: re-login
+        with the app password, retry the remaining images, publish them all —
+        never a text-only fallback, never a dead-token retry loop."""
         import database
         import scheduler
         from bluesky import BlueskyAuthError
 
         sent = []
         uploads = []
+        logins = {"count": 0}
         monkeypatch.setattr(
             scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
         )
         _stub_session(monkeypatch)
+
+        def counting_session(pds, handle, pw):
+            logins["count"] += 1
+            return {
+                "did": "did:plc:test123",
+                "access_jwt": f"aj-{logins['count']}",
+                "refresh_jwt": f"rj-{logins['count']}",
+            }
+
+        monkeypatch.setattr(scheduler, "create_session", counting_session)
         monkeypatch.setattr(
             scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
         )
 
-        def expiring_upload(**kw):
+        def flaky_upload(**kw):
             uploads.append(kw)
-            if len(uploads) == 1:
-                return {"$type": "blob", "ref": {"$link": "bafkreifake"}}
-            raise BlueskyAuthError("Blob upload rejected: session expired (ExpiredToken)")
+            if len(uploads) == 2:
+                # Second image: rejected once, then accepted after re-login.
+                raise BlueskyAuthError(
+                    "Blob upload rejected: session expired (ExpiredToken)"
+                )
+            return {"$type": "blob", "ref": {"$link": "bafkreifake"}}
 
-        monkeypatch.setattr(scheduler, "upload_blob", expiring_upload)
+        monkeypatch.setattr(scheduler, "upload_blob", flaky_upload)
         import alt_text
 
         monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
@@ -779,14 +793,68 @@ class TestSendBluesky:
         ])
         ok = scheduler.process_echo(echo, item)
 
-        assert ok is False  # transient: bounded retry re-auths and retries
-        assert len(sent) == 0  # nothing published
+        assert ok is True
+        assert len(sent) == 1
+        assert len(sent[0]["embed"]["images"]) == 2  # both images made it
+        assert len(uploads) == 3  # the rejected upload was retried once
+        assert logins["count"] == 2  # initial login + one re-auth
+        with database.get_db() as db:
+            account = db.execute(
+                "SELECT access_jwt FROM bluesky_accounts WHERE id = 1"
+            ).fetchone()
+            assert account["access_jwt"] == "aj-2"  # fresh session persisted
+
+    def test_auth_error_during_upload_with_dead_credentials_gives_up(
+        self, db_tmp, monkeypatch
+    ):
+        """When the re-login itself is rejected, no retry can help: fail
+        permanently, publish nothing."""
+        import database
+        import scheduler
+        from bluesky import BlueskyAuthError
+
+        sent = []
+        logins = {"count": 0}
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+
+        def dead_session(pds, handle, pw):
+            logins["count"] += 1
+            if logins["count"] == 1:
+                return {"did": "did:plc:test123", "access_jwt": "aj", "refresh_jwt": "rj"}
+            raise BlueskyAuthError("Authentication Required")
+
+        monkeypatch.setattr(scheduler, "create_session", dead_session)
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+
+        def rejected_upload(**kw):
+            raise BlueskyAuthError(
+                "Blob upload rejected: session expired (ExpiredToken)"
+            )
+
+        monkeypatch.setattr(scheduler, "upload_blob", rejected_upload)
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/1.jpg", "alt": ""},
+        ])
+        ok = scheduler.process_echo(echo, item)
+
+        assert ok is True  # terminal failure unblocks the cursor
+        assert len(sent) == 0
         with database.get_db() as db:
             row = db.execute(
                 "SELECT status, error_message FROM posted_items WHERE echo_id = 1"
             ).fetchone()
-            assert row["status"] == "failed"
-            assert "session rejected" in row["error_message"]
+            assert row["status"] == "gave_up"
+            assert "credentials" in row["error_message"]
 
     def test_http_error_on_upload_skips_only_that_image(self, db_tmp, monkeypatch):
         """Non-auth PDS upload rejections stay image-level: skip that image,
@@ -879,6 +947,53 @@ class TestSendBluesky:
                 "SELECT access_jwt FROM bluesky_accounts WHERE id = 1"
             ).fetchone()
             assert row["access_jwt"] == "aj"  # refreshed via stub create_session
+
+    def test_post_url_uses_refreshed_did_after_reauth(self, db_tmp, monkeypatch):
+        """post_url must name the DID that actually published when a
+        mid-post re-login resolved a different one."""
+        import database
+        import scheduler
+        from bluesky import BlueskyAuthError
+
+        calls = {"count": 0}
+        logins = {"count": 0}
+
+        def flaky_post(**kw):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise BlueskyAuthError("ExpiredToken")
+            return {"uri": "u", "cid": "c"}
+
+        monkeypatch.setattr(scheduler, "create_post", flaky_post)
+        _stub_session(monkeypatch)
+
+        def rotating_session(pds, handle, pw):
+            logins["count"] += 1
+            did = (
+                "did:plc:test123"
+                if logins["count"] == 1
+                else "did:plc:refreshed"
+            )
+            return {
+                "did": did,
+                "access_jwt": f"aj{logins['count']}",
+                "refresh_jwt": f"rj{logins['count']}",
+            }
+
+        monkeypatch.setattr(scheduler, "create_session", rotating_session)
+
+        echo = _setup_bluesky_echo(db_tmp)
+        ok = scheduler.process_echo(echo, _item())
+
+        assert ok is True
+        with database.get_db() as db:
+            row = db.execute(
+                "SELECT post_url FROM posted_items WHERE echo_id = 1"
+            ).fetchone()
+        assert (
+            row["post_url"]
+            == "https://bsky.app/profile/did:plc:refreshed/post/u"
+        )
 
     def test_persistent_auth_failure_gives_up_permanently(self, db_tmp, monkeypatch):
         import database

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -314,6 +314,44 @@ class TestBuildFacets:
         facets = build_facets(clipped)
         assert facets == []
 
+class TestBuildImageEmbed:
+    def test_wraps_multiple_entries_with_alts(self):
+        from bluesky import build_image_embed
+
+        blob = {"$type": "blob", "ref": {"$link": "bafy"}}
+        embed = build_image_embed([
+            {"blob": blob, "alt": " one "},
+            {"blob": blob, "alt": "two"},
+        ])
+        assert embed["$type"] == "app.bsky.embed.images"
+        assert [img["alt"] for img in embed["images"]] == ["one", "two"]
+        assert all(img["image"] is blob for img in embed["images"])
+
+    def test_caps_at_max_images(self):
+        from bluesky import MAX_IMAGES, build_image_embed
+
+        entries = [
+            {"blob": {"$type": "blob"}, "alt": str(i)}
+            for i in range(MAX_IMAGES + 2)
+        ]
+        embed = build_image_embed(entries)
+        assert len(embed["images"]) == MAX_IMAGES
+
+    def test_truncates_long_alt_text(self):
+        from bluesky import MAX_ALT_GRAPHEMES, build_image_embed
+
+        embed = build_image_embed([
+            {"blob": {"$type": "blob"}, "alt": "x" * (MAX_ALT_GRAPHEMES + 50)},
+        ])
+        assert len(embed["images"][0]["alt"]) == MAX_ALT_GRAPHEMES
+
+    def test_empty_entries_raise_value_error(self):
+        from bluesky import build_image_embed
+
+        with pytest.raises(ValueError):
+            build_image_embed([])
+
+
 # ── Session expiry ───────────────────────────────────────────────────────────
 
 class TestSessionExpiry:
@@ -704,6 +742,116 @@ class TestSendBluesky:
         assert [
             img["alt"] for img in sent[0]["embed"]["images"]
         ] == ["USER EDITED ALT", "AI-GENERATED"]
+
+    def test_auth_error_during_upload_fails_post_for_retry(self, db_tmp, monkeypatch):
+        """A session rejected mid-upload must fail the post (for a fresh-
+        session retry), never publish a text-only success with images
+        silently dropped."""
+        import database
+        import scheduler
+        from bluesky import BlueskyAuthError
+
+        sent = []
+        uploads = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+
+        def expiring_upload(**kw):
+            uploads.append(kw)
+            if len(uploads) == 1:
+                return {"$type": "blob", "ref": {"$link": "bafkreifake"}}
+            raise BlueskyAuthError("Blob upload rejected: session expired (ExpiredToken)")
+
+        monkeypatch.setattr(scheduler, "upload_blob", expiring_upload)
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/1.jpg", "alt": ""},
+            {"url": "https://example.com/2.jpg", "alt": ""},
+        ])
+        ok = scheduler.process_echo(echo, item)
+
+        assert ok is False  # transient: bounded retry re-auths and retries
+        assert len(sent) == 0  # nothing published
+        with database.get_db() as db:
+            row = db.execute(
+                "SELECT status, error_message FROM posted_items WHERE echo_id = 1"
+            ).fetchone()
+            assert row["status"] == "failed"
+            assert "session rejected" in row["error_message"]
+
+    def test_http_error_on_upload_skips_only_that_image(self, db_tmp, monkeypatch):
+        """Non-auth PDS upload rejections stay image-level: skip that image,
+        keep the rest of the post (same contract as Mastodon's upload_media)."""
+        import scheduler
+        from bluesky import BlueskyError
+
+        sent = []
+        uploads = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+
+        def failing_upload(**kw):
+            uploads.append(kw)
+            if len(uploads) == 1:
+                raise BlueskyError("Blob upload failed (HTTP 500)")
+            return {"$type": "blob", "ref": {"$link": "bafkreifake"}}
+
+        monkeypatch.setattr(scheduler, "upload_blob", failing_upload)
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/1.jpg", "alt": ""},
+            {"url": "https://example.com/2.jpg", "alt": ""},
+        ])
+        ok = scheduler.process_echo(echo, item)
+
+        assert ok is True
+        assert len(sent[0]["embed"]["images"]) == 1
+
+    def test_all_images_failed_warns_text_only(self, db_tmp, monkeypatch, caplog):
+        """When every candidate image is skipped, the degrade to text-only is
+        logged (the old code had a per-branch warning; the loop needs one)."""
+        import logging
+        import scheduler
+
+        sent = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+        monkeypatch.setattr(scheduler, "fetch_image", lambda url: None)
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/1.jpg", "alt": ""},
+            {"url": "https://example.com/2.jpg", "alt": ""},
+        ])
+        with caplog.at_level(logging.WARNING):
+            ok = scheduler.process_echo(echo, item)
+
+        assert ok is True
+        assert sent[0]["embed"] is None
+        assert "no images uploaded" in caplog.text
 
     def test_auth_error_retries_with_fresh_session(self, db_tmp, monkeypatch):
         import database

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -492,6 +492,219 @@ class TestSendBluesky:
         assert len(upload_calls) == 0
         assert sent[0]["embed"] is None
 
+    def test_attaches_up_to_four_images_from_image_urls(self, db_tmp, monkeypatch):
+        """image_urls drives a multi-image embed (Bluesky cap 4), per-image alt."""
+        import scheduler
+
+        sent = []
+        uploaded = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+        monkeypatch.setattr(
+            scheduler,
+            "upload_blob",
+            lambda **kw: uploaded.append(kw)
+            or {"$type": "blob", "ref": {"$link": "bafkreifake"}},
+        )
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/1.jpg", "alt": "one"},
+            {"url": "https://example.com/2.jpg", "alt": "two"},
+            {"url": "https://example.com/3.jpg", "alt": ""},
+        ])
+        scheduler.process_echo(echo, item)
+
+        assert len(uploaded) == 3
+        embed = sent[0]["embed"]
+        assert embed["$type"] == "app.bsky.embed.images"
+        assert [img["alt"] for img in embed["images"]] == ["one", "two", ""]
+        assert all(
+            img["image"]["ref"]["$link"] == "bafkreifake" for img in embed["images"]
+        )
+
+    def test_caps_at_four_images(self, db_tmp, monkeypatch):
+        """More than 4 image_urls are truncated to Bluesky's cap of 4."""
+        import scheduler
+
+        sent = []
+        upload_count = [0]
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+
+        def fake_upload(**kw):
+            upload_count[0] += 1
+            return {"$type": "blob", "ref": {"$link": f"bafkrei{upload_count[0]}"}}
+
+        monkeypatch.setattr(scheduler, "upload_blob", fake_upload)
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": f"https://example.com/{i}.jpg", "alt": ""} for i in range(6)
+        ])
+        scheduler.process_echo(echo, item)
+
+        assert upload_count[0] == 4
+        assert len(sent[0]["embed"]["images"]) == 4
+
+    def test_failed_image_fetch_skips_only_that_image(self, db_tmp, monkeypatch):
+        """One dead image URL never drops the rest of the attachments."""
+        import scheduler
+
+        sent = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+
+        def flaky_fetch(url):
+            if "broken" in url:
+                return None
+            return (b"fake-image-bytes", "image/jpeg")
+
+        monkeypatch.setattr(scheduler, "fetch_image", flaky_fetch)
+        monkeypatch.setattr(
+            scheduler,
+            "upload_blob",
+            lambda **kw: {"$type": "blob", "ref": {"$link": "bafkreifake"}},
+        )
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/broken.jpg", "alt": ""},
+            {"url": "https://example.com/good.jpg", "alt": ""},
+        ])
+        scheduler.process_echo(echo, item)
+
+        assert len(sent[0]["embed"]["images"]) == 1
+
+    def test_unsupported_type_skips_only_that_image(self, db_tmp, monkeypatch):
+        """A non-image content type skips that image, keeps the supported one."""
+        import scheduler
+
+        sent = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+
+        def typed_fetch(url):
+            if url.endswith(".avif"):
+                return (b"bytes", "image/avif")
+            return (b"fake-image-bytes", "image/jpeg")
+
+        monkeypatch.setattr(scheduler, "fetch_image", typed_fetch)
+        monkeypatch.setattr(
+            scheduler,
+            "upload_blob",
+            lambda **kw: {"$type": "blob", "ref": {"$link": "bafkreifake"}},
+        )
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/photo.avif", "alt": ""},
+            {"url": "https://example.com/photo.jpg", "alt": ""},
+        ])
+        scheduler.process_echo(echo, item)
+
+        assert len(sent[0]["embed"]["images"]) == 1
+
+    def test_upload_rejection_skips_only_that_image(self, db_tmp, monkeypatch):
+        """An upload that comes back empty skips that image, keeps the rest."""
+        import scheduler
+
+        sent = []
+        uploads = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+
+        def flaky_upload(**kw):
+            uploads.append(kw)
+            if len(uploads) == 1:
+                return None
+            return {"$type": "blob", "ref": {"$link": "bafkreifake"}}
+
+        monkeypatch.setattr(scheduler, "upload_blob", flaky_upload)
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(image_urls=[
+            {"url": "https://example.com/1.jpg", "alt": ""},
+            {"url": "https://example.com/2.jpg", "alt": ""},
+        ])
+        scheduler.process_echo(echo, item)
+
+        assert len(uploads) == 2
+        assert len(sent[0]["embed"]["images"]) == 1
+
+    def test_user_alt_override_on_primary_slot(self, db_tmp, monkeypatch):
+        """item['image_alt'] (user-edited) wins for the first image; the
+        secondary slot falls back to AI generation."""
+        import scheduler
+
+        sent = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+        monkeypatch.setattr(
+            scheduler, "fetch_image", lambda url: (b"fake-image-bytes", "image/jpeg")
+        )
+        monkeypatch.setattr(
+            scheduler,
+            "upload_blob",
+            lambda **kw: {"$type": "blob", "ref": {"$link": "bafkreifake"}},
+        )
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: True)
+        monkeypatch.setattr(
+            alt_text, "generate_alt_text", lambda *a, **kw: "AI-GENERATED"
+        )
+
+        echo = _setup_bluesky_echo(db_tmp, {"attach_image": 1})
+        item = _item(
+            image_alt="USER EDITED ALT",
+            image_urls=[
+                {"url": "https://example.com/1.jpg", "alt": ""},
+                {"url": "https://example.com/2.jpg", "alt": ""},
+            ],
+        )
+        scheduler.process_echo(echo, item)
+
+        assert [
+            img["alt"] for img in sent[0]["embed"]["images"]
+        ] == ["USER EDITED ALT", "AI-GENERATED"]
+
     def test_auth_error_retries_with_fresh_session(self, db_tmp, monkeypatch):
         import database
         import scheduler

--- a/tests/test_images_downscale_and_alt_url.py
+++ b/tests/test_images_downscale_and_alt_url.py
@@ -631,6 +631,52 @@ class TestBlueskyDownscaleWiring:
         assert len(uploaded[0]["image_bytes"]) <= 2_000_000
         assert len(uploaded[0]["image_bytes"]) != len(big)
 
+    def test_multi_image_downscales_each_independently(
+        self, db_tmp, monkeypatch, bl_echo
+    ):
+        """Two images: the small one passes through untouched, the oversized
+        one is downscaled, and both attach in one embed."""
+        import scheduler
+
+        sent = []
+        uploaded = []
+        monkeypatch.setattr(
+            scheduler,
+            "create_post",
+            lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"},
+        )
+        self._stub_bsky_session(monkeypatch)
+        small = _jpeg_bytes(width=640, height=480)
+        big = _jpeg_bytes(width=4000, height=3000)
+        assert len(big) > 2_000_000
+
+        def sized_fetch(url):
+            return (big if "big" in url else small, "image/jpeg")
+
+        monkeypatch.setattr(scheduler, "fetch_image", sized_fetch)
+        monkeypatch.setattr(
+            scheduler,
+            "upload_blob",
+            lambda **kw: uploaded.append(kw)
+            or {"$type": "blob", "ref": {"$link": "b"}},
+        )
+        import alt_text
+
+        monkeypatch.setattr(alt_text, "is_enabled", lambda user_id=1: False)
+
+        item = self._bl_item(image_urls=[
+            {"url": "https://example.com/small.jpg", "alt": ""},
+            {"url": "https://example.com/big.jpg", "alt": ""},
+        ])
+        ok = scheduler.process_echo(bl_echo, item)
+
+        assert ok is True
+        assert len(uploaded) == 2
+        assert uploaded[0]["image_bytes"] == small
+        assert len(uploaded[1]["image_bytes"]) <= 2_000_000
+        assert len(uploaded[1]["image_bytes"]) != len(big)
+        assert len(sent[0]["embed"]["images"]) == 2
+
     def test_max_blob_bytes_constant_tracks_bluesky_limit(self):
         """The 1 MB constant was stale when Bluesky raised its embed limit to
         2 MB in April 2026 (atproto PR #4823); pin the new ceiling."""


### PR DESCRIPTION
## Why

A member report: a feed post with 3 images landed on Mastodon with all 3, but on Bluesky with only 1. Root cause: `_send_bluesky` only ever attached the item's legacy single `image_url` — the v1.49.0 multi-image work (`image_urls` extraction + upload loop) only ever reached the Mastodon destination. Bluesky's `app.bsky.embed.images` takes up to 4 images, so this is a parity gap, not a platform limit.

## What changed

Bluesky now attaches up to 4 images per post, mirroring the Mastodon dispatch:

- Uses the shared `_item_image_entries` (item `image_urls`, JSON-string tolerant, single-`image_url` fallback for legacy rows, user-edited alt applied to the primary slot).
- Per-image alt precedence: feed-provided alt > user-edited (primary slot) > AI generation.
- Per-image failure isolation: a dead link, unsupported type, oversized-after-downscale, or non-auth upload rejection skips just that image (parity with Mastodon's `upload_media` contract).
- Oversized images are downscaled per image to Bluesky's 2 MB blob limit (existing `images.downscale_image` path, now per image).
- Session rejected mid-upload heals in-dispatch: `_bsky_reauth` re-logins with the stored app password and the loop retries the remaining images; a second rejection fails permanently ("Bluesky credentials rejected"). `create_post`'s re-auth block now shares the same helper.
- `build_image_embed` takes a list of `{blob, alt}` entries; empty input raises (the lexicon requires at least one image).
- Docs: README, How-To, and the echo form's Attach-image hint describe the real per-destination image behavior (Mastodon/Bluesky up to 4; email up to 4 inline; Matrix, micro.blog, Discord first image).

## Review

Gemini 3.8 Flash review gate on the diff, four rounds — every finding triaged against source and fixed, notably:

- R1: auth errors during upload were swallowed into a silent text-only post; missing all-failed warning; embed guard; stale-DID `post_url`.
- R2: rejected the first recovery design (a scheduler retry cannot heal a rejected session — `_bsky_session` returns the cached token while `session_expires_at` reads valid) → reworked to in-dispatch re-auth.
- R3: caught an off-by-index in the retry resume (`len(image_entries_out)` used as an input index) that could re-upload an already-sent image as a duplicate after a skip → fixed with explicit `start_idx`; regression test added (RED against the old slicing).

## Tests

1668 sqlite + 47 pg green. New coverage: multi-image attach, cap at 4, per-image skip (fetch/type/upload), per-image alt precedence, independent downscale, mid-upload session heal (fresh token asserted on the retried upload and the post), dead-credentials `gave_up`, skip-before-auth no-duplicate, refreshed-DID `post_url`, `build_image_embed` units.
