### PR TITLE
Bluesky hashtag facets: #tags render as real Bluesky tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A hosted version with accounts, plans, and a 14-day free trial is live at [feede
 
 - **RSS/Atom/JSON feed support** via feedparser
 - **Mastodon OAuth** — connect accounts with one click, no manual token creation
-- **Bluesky support** — connect accounts with an App Password; posts get auto-detected link facets, 300-grapheme truncation, and image embeds with alt text
+- **Bluesky support** — connect accounts with an App Password; posts get auto-detected link and hashtag facets (links clickable, hashtags as real, searchable tags), 300-grapheme truncation, and image embeds with alt text
 - **micro.blog support** — connect with a Micropub app token; FeedEcho discovers every blog the token can post to and posts with the item's image attached
 - **Matrix support** — connect a room with an access token; posts go in as `m.room.message` events with clickable links, uploaded images, and homeserver-side de-duplication on retries
 - **Discord support** — connect a channel with a webhook URL; posts land in the channel with an embed carrying the title, link, and image
@@ -169,7 +169,7 @@ FeedEcho ships a Nix flake and a NixOS module. See [`nix/README.md`](nix/README.
 
 - Accounts connect via **App Passwords**, which are scoped to creating posts (and other app activity) and can be revoked individually without changing your main password.
 - Sessions are cached per account (access + refresh JWTs in SQLite) and refreshed automatically; expired tokens trigger a transparent re-login and one retry.
-- Posts are truncated to **300 graphemes** (Unicode-aware) and, separately, to Bluesky's 3000-byte limit on the post text; URLs in the text get proper link facets, so links are clickable everywhere.
+- Posts are truncated to **300 graphemes** (Unicode-aware) and, separately, to Bluesky's 3000-byte limit on the post text; URLs and #hashtags in the text get proper richtext facets, so links are clickable and hashtags become real, searchable Bluesky tags.
 - Image attachments upload through the PDS blob API with an `app.bsky.embed.images` embed carrying **up to 4 images** per post; each image's alt text uses the feed's own description when it provides one, otherwise your AI vision config when enabled. Images are capped at 2 MB each and jpeg/png/webp/gif (Bluesky's limits); oversized JPEG/PNG/WebP sources are downscaled or re-encoded to fit automatically, and one image that fails to fetch or upload is skipped without dropping the rest of the post.
 - Content warnings and visibility settings are Mastodon-only and are ignored for Bluesky posts.
 

--- a/bluesky.py
+++ b/bluesky.py
@@ -329,7 +329,7 @@ def _strip_trailing_punctuation(value: str) -> str:
 
 
 def _has_tag_body_char(tag: str) -> bool:
-    """Whether the tag keeps a character that is neither digit nor punctuation.
+    r"""Whether the tag keeps a character that is neither digit nor punctuation.
 
     atproto's TAG_REGEX requires one such character inside the body; it is
     what makes "#123" render as plain text rather than a tag. Only ASCII
@@ -411,10 +411,12 @@ def build_facets(text: str) -> list[dict]:
         tag = _strip_trailing_punctuation(candidate[1:])
         if not tag:
             continue
-        # Client parity: atproto drops a tag only when BOTH its code-point
-        # count and its grapheme count exceed 64. The tag lexicon separately
-        # caps the property at 640 UTF-8 bytes; an oversized tag facet would
-        # fail record validation and kill the whole post, so guard that too.
+        # Tag cap: 64 graphemes (the lexicon limit). len(tag) is the cheap
+        # pre-check the client also uses -- code points are always >=
+        # graphemes, so cluster counting only runs for over-cap raw lengths.
+        # The lexicon separately caps the property at 640 UTF-8 bytes; an
+        # oversized tag facet would fail record validation and kill the
+        # whole post, so guard that too.
         if (
             len(tag) > _TAG_MAX_CHARS
             and len(_grapheme_clusters(tag)) > _TAG_MAX_CHARS

--- a/bluesky.py
+++ b/bluesky.py
@@ -304,9 +304,10 @@ _URL_RE = re.compile(r"https?://[^\s<>\"']+")
 # beginning of the text or after whitespace, uses an ASCII or fullwidth
 # hash, and runs to the next whitespace or zero-width character. The
 # candidate's trailing punctuation is stripped, it must keep at least one
-# character that is neither a digit nor punctuation (so "#123" is not a
-# tag), and it caps at 64 characters -- the limits the official client
-# applies. Cashtags ($TICKER) and mentions (@handle) are deliberately not
+# character that is neither an ASCII digit nor punctuation (so "#123" is
+# not a tag while a tag of non-ASCII digits is -- JS \d matches ASCII
+# only), and it caps at 64 graphemes / 640 bytes -- the client and the
+# tag lexicon limits. Cashtags ($TICKER) and mentions (@handle) are deliberately not
 # detected: feeds carry foreign @user@instance handles that cannot resolve
 # to Bluesky DIDs, and $TICKER content is rare in feeds.
 _TAG_RE = re.compile(
@@ -314,6 +315,8 @@ _TAG_RE = re.compile(
 )
 _TAG_ZERO_WIDTH = "\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2"
 _TAG_MAX_CHARS = 64
+_TAG_MAX_BYTES = 640
+_ASCII_DIGITS = "0123456789"
 _FACET_LINK_TYPE = "app.bsky.richtext.facet#link"
 _FACET_TAG_TYPE = "app.bsky.richtext.facet#tag"
 
@@ -329,12 +332,14 @@ def _has_tag_body_char(tag: str) -> bool:
     """Whether the tag keeps a character that is neither digit nor punctuation.
 
     atproto's TAG_REGEX requires one such character inside the body; it is
-    what makes "#123" render as plain text rather than a tag.
+    what makes "#123" render as plain text rather than a tag. Only ASCII
+    digits are excluded (JS \d is ASCII-only), so a tag of non-ASCII digits
+    like "#٢٠٢٦" is a tag to the official client and stays one here.
     """
     for ch in tag:
         if ch in _TAG_ZERO_WIDTH or ch.isspace():
             continue
-        if ch.isdigit():
+        if ch in _ASCII_DIGITS:
             continue
         if unicodedata.category(ch).startswith("P"):
             continue
@@ -404,7 +409,18 @@ def build_facets(text: str) -> list[dict]:
         if "…" in candidate:
             continue
         tag = _strip_trailing_punctuation(candidate[1:])
-        if not tag or len(tag) > _TAG_MAX_CHARS:
+        if not tag:
+            continue
+        # Client parity: atproto drops a tag only when BOTH its code-point
+        # count and its grapheme count exceed 64. The tag lexicon separately
+        # caps the property at 640 UTF-8 bytes; an oversized tag facet would
+        # fail record validation and kill the whole post, so guard that too.
+        if (
+            len(tag) > _TAG_MAX_CHARS
+            and len(_grapheme_clusters(tag)) > _TAG_MAX_CHARS
+        ):
+            continue
+        if len(tag.encode("utf-8")) > _TAG_MAX_BYTES:
             continue
         if not _has_tag_body_char(tag):
             continue

--- a/bluesky.py
+++ b/bluesky.py
@@ -299,18 +299,65 @@ def session_expiry(access_jwt: str) -> str:
 
 
 _URL_RE = re.compile(r"https?://[^\s<>\"']+")
+# Hashtag detection mirrors Bluesky's own richtext rules (atproto:
+# packages/api/src/rich-text/util.ts TAG_REGEX): a tag starts at the
+# beginning of the text or after whitespace, uses an ASCII or fullwidth
+# hash, and runs to the next whitespace or zero-width character. The
+# candidate's trailing punctuation is stripped, it must keep at least one
+# character that is neither a digit nor punctuation (so "#123" is not a
+# tag), and it caps at 64 characters -- the limits the official client
+# applies. Cashtags ($TICKER) and mentions (@handle) are deliberately not
+# detected: feeds carry foreign @user@instance handles that cannot resolve
+# to Bluesky DIDs, and $TICKER content is rare in feeds.
+_TAG_RE = re.compile(
+    r"(^|\s)([#＃](?!\ufe0f)[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*)"
+)
+_TAG_ZERO_WIDTH = "\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2"
+_TAG_MAX_CHARS = 64
 _FACET_LINK_TYPE = "app.bsky.richtext.facet#link"
+_FACET_TAG_TYPE = "app.bsky.richtext.facet#tag"
+
+
+def _strip_trailing_punctuation(value: str) -> str:
+    """Drop trailing Unicode punctuation (atproto trim + TRAILING_PUNCTUATION)."""
+    while value and unicodedata.category(value[-1]).startswith("P"):
+        value = value[:-1]
+    return value
+
+
+def _has_tag_body_char(tag: str) -> bool:
+    """Whether the tag keeps a character that is neither digit nor punctuation.
+
+    atproto's TAG_REGEX requires one such character inside the body; it is
+    what makes "#123" render as plain text rather than a tag.
+    """
+    for ch in tag:
+        if ch in _TAG_ZERO_WIDTH or ch.isspace():
+            continue
+        if ch.isdigit():
+            continue
+        if unicodedata.category(ch).startswith("P"):
+            continue
+        return True
+    return False
 
 
 def build_facets(text: str) -> list[dict]:
-    """Find URLs in post text and build link facets with UTF-8 byte offsets.
+    """Find URLs and hashtags in post text and build richtext facets.
 
     Byte offsets are relative to the UTF-8 encoding of the text, as required
-    by app.bsky.richtext.facet. Trailing punctuation is trimmed from each URL
-    so it is not swallowed into the link.
+    by app.bsky.richtext.facet. Link and tag detection follow Bluesky's own
+    richtext rules: trailing punctuation is trimmed from each URL; a tag must
+    start the text or follow whitespace, and keeps at least one non-digit,
+    non-punctuation character. Truncation artifacts are dropped ("…" inside a
+    match), and a tag candidate overlapping a URL range is skipped so facets
+    never overlap.
     """
     encoded = text.encode("utf-8")
-    facets: list[dict] = []
+
+    # (char_start, char_end, facet) — overlap checks run in character space;
+    # byte offsets are derived from character positions per final match.
+    found: list[tuple[int, int, dict]] = []
 
     for match in _URL_RE.finditer(text):
         uri = match.group(0)
@@ -334,16 +381,56 @@ def build_facets(text: str) -> list[dict]:
         if byte_end > len(encoded) or encoded[byte_start:byte_end].decode("utf-8") != uri:
             continue
 
-        facets.append(
-            {
-                "index": {"byteStart": byte_start, "byteEnd": byte_end},
-                "features": [
-                    {"$type": _FACET_LINK_TYPE, "uri": uri},
-                ],
-            }
+        found.append(
+            (
+                char_start,
+                char_start + len(uri),
+                {
+                    "index": {"byteStart": byte_start, "byteEnd": byte_end},
+                    "features": [
+                        {"$type": _FACET_LINK_TYPE, "uri": uri},
+                    ],
+                },
+            )
         )
 
-    return facets
+    link_spans = [(start, end) for start, end, _ in found]
+
+    for match in _TAG_RE.finditer(text):
+        leading = match.group(1)
+        candidate = match.group(2)
+        # Same truncation guard as URLs: an ellipsis inside the candidate
+        # means the tag was sliced mid-word.
+        if "…" in candidate:
+            continue
+        tag = _strip_trailing_punctuation(candidate[1:])
+        if not tag or len(tag) > _TAG_MAX_CHARS:
+            continue
+        if not _has_tag_body_char(tag):
+            continue
+
+        char_start = match.start() + len(leading)  # position of the hash
+        char_end = char_start + 1 + len(tag)
+        if any(char_start < end and start < char_end for start, end in link_spans):
+            continue
+
+        byte_start = len(text[:char_start].encode("utf-8"))
+        byte_end = len(text[:char_end].encode("utf-8"))
+        found.append(
+            (
+                char_start,
+                char_end,
+                {
+                    "index": {"byteStart": byte_start, "byteEnd": byte_end},
+                    "features": [
+                        {"$type": _FACET_TAG_TYPE, "tag": tag},
+                    ],
+                },
+            )
+        )
+
+    found.sort(key=lambda entry: entry[0])
+    return [facet for _, _, facet in found]
 
 
 # ── Grapheme-aware truncation ────────────────────────────────────────────────

--- a/templates/howto.html
+++ b/templates/howto.html
@@ -76,6 +76,7 @@
                 <li><strong>Filter keywords</strong> — post only items containing a keyword, or skip items containing it.</li>
                 <li><strong>Content warning</strong> — for Mastodon, adds a spoiler label and marks posts sensitive.</li>
                 <li><strong>Attach image</strong> — include the item's images with the post where the destination supports media uploads (up to 4 on Mastodon and Bluesky; email embeds up to 4 inline; Matrix, micro.blog, and Discord use the first).</li>
+                <li><strong>Links and hashtags</strong> — URLs in the post text stay clickable and <code>#hashtags</code> become real, searchable tags on Mastodon and Bluesky.</li>
                 <li><strong>Drip limit</strong> — cap the echo at N posts per hour; extra items wait in a queue and release as the window slides. 0 = off.</li>
                 <li><strong>Digest</strong> — email destinations only; batches items into one email per hour instead of sending per item.</li>
             </ul>

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -314,6 +314,139 @@ class TestBuildFacets:
         facets = build_facets(clipped)
         assert facets == []
 
+    # ── hashtag facets ─────────────────────────────────────────────────────
+
+    def test_tag_facet_basic(self):
+        from bluesky import build_facets
+
+        text = "Hello #world"
+        facets = build_facets(text)
+        assert len(facets) == 1
+        assert facets[0]["features"][0] == {
+            "$type": "app.bsky.richtext.facet#tag",
+            "tag": "world",
+        }
+        start, end = facets[0]["index"]["byteStart"], facets[0]["index"]["byteEnd"]
+        assert text.encode("utf-8")[start:end].decode() == "#world"
+
+    def test_tag_real_post_shape(self):
+        """The exact shape of the post that prompted the fix (2026-09-11):
+        title, blank line, URL, blank line, hashtag."""
+        from bluesky import build_facets
+
+        text = (
+            "Arriving in Kristiansand, Norway.\n\n"
+            "https://glass.photo/digitalpardoe/36Khk4eOLYsafBXiOclVBC\n\n"
+            "#Photography"
+        )
+        facets = build_facets(text)
+        assert len(facets) == 2
+        link, tag = facets
+        assert link["features"][0]["$type"] == "app.bsky.richtext.facet#link"
+        assert tag["features"][0] == {
+            "$type": "app.bsky.richtext.facet#tag",
+            "tag": "Photography",
+        }
+        start, end = tag["index"]["byteStart"], tag["index"]["byteEnd"]
+        assert text.encode("utf-8")[start:end].decode() == "#Photography"
+
+    def test_tag_multibyte_prefix_offsets(self):
+        from bluesky import build_facets
+
+        prefix = "café ☕ "
+        text = prefix + "#photo"
+        facets = build_facets(text)
+        start, end = facets[0]["index"]["byteStart"], facets[0]["index"]["byteEnd"]
+        assert start == len(prefix.encode("utf-8"))
+        assert end == len(text.encode("utf-8"))
+
+    def test_tag_trailing_punctuation_trimmed(self):
+        from bluesky import build_facets
+
+        text = "Nice shot #photo!"
+        facets = build_facets(text)
+        assert facets[0]["features"][0]["tag"] == "photo"
+        start, end = facets[0]["index"]["byteStart"], facets[0]["index"]["byteEnd"]
+        assert text.encode("utf-8")[start:end].decode() == "#photo"
+
+    def test_tag_at_start_of_text(self):
+        from bluesky import build_facets
+
+        facets = build_facets("#first post")
+        assert facets[0]["features"][0]["tag"] == "first"
+        assert facets[0]["index"]["byteStart"] == 0
+        assert facets[0]["index"]["byteEnd"] == len("#first".encode("utf-8"))
+
+    def test_tag_digit_only_skipped(self):
+        from bluesky import build_facets
+
+        assert build_facets("count #123 things") == []
+
+    def test_tag_all_punctuation_skipped(self):
+        from bluesky import build_facets
+
+        assert build_facets("wow #!!!") == []
+
+    def test_tag_fullwidth_hash(self):
+        from bluesky import build_facets
+
+        text = "＃photo"
+        facets = build_facets(text)
+        assert facets[0]["features"][0]["tag"] == "photo"
+        start, end = facets[0]["index"]["byteStart"], facets[0]["index"]["byteEnd"]
+        assert start == 0
+        assert text.encode("utf-8")[start:end].decode() == "＃photo"
+
+    def test_multiple_tags_sorted(self):
+        from bluesky import build_facets
+
+        facets = build_facets("#one two #three")
+        assert [f["features"][0]["tag"] for f in facets] == ["one", "three"]
+        starts = [f["index"]["byteStart"] for f in facets]
+        assert starts == sorted(starts)
+
+    def test_tag_inside_url_not_duplicated(self):
+        from bluesky import build_facets
+
+        facets = build_facets("see https://example.com/page#anchor")
+        assert len(facets) == 1
+        assert facets[0]["features"][0]["$type"] == "app.bsky.richtext.facet#link"
+
+    def test_url_and_tag_both_detected(self):
+        from bluesky import build_facets
+
+        facets = build_facets("read https://example.com/a then #tag")
+        assert [f["features"][0]["$type"] for f in facets] == [
+            "app.bsky.richtext.facet#link",
+            "app.bsky.richtext.facet#tag",
+        ]
+
+    def test_clipped_tag_dropped(self):
+        """A tag sliced by truncation must not become a broken tag facet."""
+        from bluesky import build_facets
+
+        assert build_facets("Ending #Photogra…") == []
+
+    def test_tag_after_paren_not_matched(self):
+        """Client parity: a tag must start the text or follow whitespace."""
+        from bluesky import build_facets
+
+        assert build_facets("(#paren)") == []
+
+    def test_tag_64_char_cap(self):
+        from bluesky import build_facets
+
+        assert build_facets("#" + "a" * 65) == []
+        tag = "a" * 64
+        facets = build_facets("#" + tag)
+        assert facets[0]["features"][0]["tag"] == tag
+
+    def test_tag_case_preserved(self):
+        from bluesky import build_facets
+
+        facets = build_facets("#PhotoGraphy")
+        assert facets[0]["features"][0]["tag"] == "PhotoGraphy"
+
 class TestBuildImageEmbed:
     def test_wraps_multiple_entries_with_alts(self):
         from bluesky import build_image_embed

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -447,6 +447,31 @@ class TestBuildFacets:
         facets = build_facets("#PhotoGraphy")
         assert facets[0]["features"][0]["tag"] == "PhotoGraphy"
 
+    def test_tag_non_ascii_digits_are_tags(self):
+        """JS \\d is ASCII-only, so the official client treats a tag of
+        non-ASCII digits as a real tag (e.g. Arabic-Indic year tags)."""
+        from bluesky import build_facets
+
+        facets = build_facets("#٢٠٢٦")
+        assert facets[0]["features"][0]["tag"] == "٢٠٢٦"
+
+    def test_tag_combining_marks_use_grapheme_cap(self):
+        """66 code points but 33 grapheme clusters: under the client cap
+        (which needs BOTH counts over 64), so the tag survives."""
+        from bluesky import build_facets
+
+        tag_body = "a\u0301" * 33
+        facets = build_facets("#" + tag_body)
+        assert facets[0]["features"][0]["tag"] == tag_body
+
+    def test_tag_over_640_bytes_dropped(self):
+        """The tag lexicon caps the property at 640 UTF-8 bytes; an oversized
+        tag facet would fail record validation and kill the whole post."""
+        from bluesky import build_facets
+
+        body = ("\U0001F600" + "\u0301" * 6) * 63  # 63 graphemes, 1008 bytes
+        assert build_facets("#" + body) == []
+
 class TestBuildImageEmbed:
     def test_wraps_multiple_entries_with_alts(self):
         from bluesky import build_image_embed
@@ -575,6 +600,34 @@ class TestSendBluesky:
             assert row["post_url"] == (
                 "https://bsky.app/profile/did:plc:test123/post/u"
             )
+
+    def test_hashtag_facet_flows_to_record(self, db_tmp, monkeypatch):
+        """A literal #hashtag in a member's template reaches the post record
+        as a tag facet (the 2026-09-11 member report)."""
+        import scheduler
+
+        sent = []
+        monkeypatch.setattr(
+            scheduler, "create_post", lambda **kw: sent.append(kw) or {"uri": "u", "cid": "c"}
+        )
+        _stub_session(monkeypatch)
+
+        echo = _setup_bluesky_echo(
+            db_tmp, {"template": "{{ title }} {{ link }} #Photography"}
+        )
+        ok = scheduler.process_echo(echo, _item())
+
+        assert ok is True
+        facets = sent[0]["facets"]
+        assert [f["features"][0]["$type"] for f in facets] == [
+            "app.bsky.richtext.facet#link",
+            "app.bsky.richtext.facet#tag",
+        ]
+        tag_facet = facets[1]
+        assert tag_facet["features"][0]["tag"] == "Photography"
+        text = sent[0]["text"]
+        start, end = tag_facet["index"]["byteStart"], tag_facet["index"]["byteEnd"]
+        assert text.encode("utf-8")[start:end].decode() == "#Photography"
 
     def test_content_truncated_to_300_graphemes(self, db_tmp, monkeypatch):
         import scheduler


### PR DESCRIPTION
## Summary

Fixes a member report: hashtags in Bluesky cross-posts rendered as plain text (not clickable/searchable tags) because FeedEcho only emitted link facets on post records. `bluesky.build_facets()` now also emits `app.bsky.richtext.facet#tag` facets, replicating the official client's detection rules: start-of-text/whitespace anchor, ASCII or fullwidth hash, trailing-punctuation strip, at least one non-ASCII-digit, non-punctuation character, 64-grapheme / 640-byte caps, UTF-8 byte offsets, sorted, never overlapping link facets, and truncation-clipped tags dropped like clipped URLs.

- Mastodon verified NOT affected (server-side linkification on the member's live post, 2026-09-11).
- Single call path: every Bluesky posting flow (normal, queue, drip, reader compose) shares `_send_bluesky` via `_DESTINATION_HANDLERS`; digests are email-only by design.
- 19 new tests; 10 verified RED against the unfixed code (the rest are parity guards). Full sqlite suite: 1687 passed.
- Docs: README (Bluesky bullet + Bluesky details) and the in-app How-To list updated.

## Review

Gemini 3.8 Flash (agy) gate on the initial diff: APPROVE, 4 LOW findings — three applied (client-exact caps, ASCII-digit rule, end-to-end test), one documented accept (ellipsis guard). Fix delta re-gated.
